### PR TITLE
Change the json-subschema dependency to track master. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'graphviz',
         'hyperopt>=0.1.1',
         'jsonschema==2.6.0',
-        'jsonsubschema @ git+https://github.com/ibm/json-subschema@96eaff4b65b6bd96dd9b569ee812ac2118c37aae',
+        'jsonsubschema @ git+https://github.com/ibm/json-subschema',
         'numpy',
         'PyYAML',
         'scikit-learn==0.20.3',


### PR DESCRIPTION
The maintainer of json-subschema plans on keeping master working.
Once there is a released version of json-subschema we will switch over to using it