### PR TITLE
Encode the dependency between the min/max part of ngram_range 

### DIFF
--- a/lale/lib/sklearn/tfidf_vectorizer.py
+++ b/lale/lib/sklearn/tfidf_vectorizer.py
@@ -83,15 +83,22 @@ _hyperparams_schema = {
                 'type': 'string',
                 'default': '(?u)\\b\\w\\w+\\b'},
             'ngram_range': {
-                'type': 'array',
-                'typeForOptimizer': 'tuple',
-                'minItemsForOptimizer': 2,
-                'maxItemsForOptimizer': 2,
-                'items': {
-                    'type': 'integer',
-                    'minimumForOptimizer': 1,
-                    'maximumForOptimizer': 3},               
-                'default': [1, 1]},
+                'default': [1, 1],
+                'anyOf': [{
+                    'type': 'array',
+                    'typeForOptimizer': 'tuple',
+                    'minItemsForOptimizer': 2,
+                    'maxItemsForOptimizer': 2,
+                    'items': {
+                        'type': 'integer',
+                        'minimumForOptimizer': 1,
+                        'maximumForOptimizer': 3},
+                    'forOptimizer':False
+                    },
+                    {
+                        'enum': [(1,1), (1,2), (1,3), (2,2), (2,3), (3,3)]
+                    }
+                ]},
             'max_df': {
                 'anyOf': [{
                     'description': 'float in range [0.0, 1.0]',

--- a/test/test.py
+++ b/test/test.py
@@ -823,7 +823,6 @@ class TestHyperoptClassifier(unittest.TestCase):
         hyperopt_classifier = HyperoptClassifier(planned, max_evals=1)
         best_found = hyperopt_classifier.fit(train_X, train_y)
 
-    @unittest.skip("TODO: debug exception, unhashable type: 'list'")
     def test_text_and_structured(self):
         from lale.datasets.uci.uci_datasets import fetch_drugscom
         from sklearn.model_selection import train_test_split


### PR DESCRIPTION
by manually expanding for search space generators.  This could be supported more cleanly if we allowed  style references in our schemas.  Enable the (now passing) test_text_and_structured test