### PR TITLE
Added a readthedocs config file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'graphviz',
         'hyperopt>=0.1.1',
         'jsonschema==2.6.0',
-        'jsonsubschema @ git+https://github.com/ibm/json-subschema@master#egg=jsonsubschema',
+        'jsonsubschema @ git+https://github.com/ibm/json-subschema',
         'numpy',
         'PyYAML',
         'scikit-learn==0.20.3',


### PR DESCRIPTION
Readthedocs needed an explicit configuration file to install using pip instead of setup.py. The default readthedocs installation did not work for jsonsubschema installation.