### PR TITLE
Add support for mapping sklearn encoded parameters in a pipeline to their defaults

### DIFF
--- a/lale/search/GridSearchCV.py
+++ b/lale/search/GridSearchCV.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from typing import Any, Dict, Iterable, Optional, List, Set, Tuple, Union
-from lale.search.search_space_grid import get_search_space_grids, SearchSpaceGrid, unnest_HPparams
-from lale.sklearn_compat import make_sklearn_compat
+from lale.search.search_space_grid import get_search_space_grids, SearchSpaceGrid
+from lale.sklearn_compat import make_sklearn_compat, unnest_HPparams
 import lale.operators as Ops
 from lale.schema_utils import Schema, getMinimum, getMaximum
 from lale.search.search_space import SearchSpace, SearchSpaceObject, SearchSpaceEnum, SearchSpaceNumber, SearchSpaceArray

--- a/lale/search/search_space_grid.py
+++ b/lale/search/search_space_grid.py
@@ -23,6 +23,7 @@ from lale.util.Visitor import Visitor
 from lale.search.search_space import SearchSpace, SearchSpaceObject, SearchSpaceEnum
 from lale.search.schema2search_space import schemaToSearchSpace
 from lale.search.PGO import PGO
+from lale.sklearn_compat import nest_all_HPparams
 
 # To avoid import cycle, since we only realy on lale.operators for types
 from typing import TYPE_CHECKING
@@ -162,18 +163,3 @@ class SearchSpaceGridVisitor(Visitor):
             ret.extend(discriminated_grids)
         return ret
 
-# Auxiliary functions
-def nest_HPparam(name:str, key:str):
-    return name + "__" + key
-
-def nest_HPparams(name:str, grid:SearchSpaceGrid)->SearchSpaceGrid:
-    return {(nest_HPparam(name, k)):v for k, v in grid.items()}
-
-def nest_all_HPparams(name:str, grids:List[SearchSpaceGrid])->List[SearchSpaceGrid]:
-    """ Given the name of an operator in a pipeline, this transforms every key(parameter name) in the grids
-        to use the operator name as a prefix (separated by __).  This is the convention in scikit-learn pipelines.
-    """
-    return [nest_HPparams(name, grid) for grid in grids]
-
-def unnest_HPparams(k:str)->List[str]:
-    return k.split("__")


### PR DESCRIPTION
This can be used by search backends to provide hints as to a good default to optimizers that support them.