### PR TITLE
Enhancements and fixes to the hyperopt classifier and regressor

### DIFF
--- a/lale/lib/lale/hyperopt_classifier.py
+++ b/lale/lib/lale/hyperopt_classifier.py
@@ -172,7 +172,7 @@ class HyperoptClassifier():
             best_params = space_eval(self.search_space, self.trials.argmin)
             logger.info('best accuracy: {:.1%}\nbest hyperparams found using {} hyperopt trials: {}'.format(-1*self.trials.average_best_error(), self.max_evals, best_params))
             trained_clf = get_final_trained_clf(best_params, X_train, y_train)
-
+            self.best_model = trained_clf
         except BaseException as e :
             logger.warning('Unable to extract the best parameters from optimization, the error: {}'.format(e))
             trained_clf = None
@@ -182,7 +182,7 @@ class HyperoptClassifier():
     def predict(self, X_eval):
         import warnings
         warnings.filterwarnings("ignore")
-        clf = self.model
+        clf = self.best_model
         try:
             predictions = clf.predict(X_eval)
         except ValueError as e:

--- a/lale/lib/lale/hyperopt_classifier.py
+++ b/lale/lib/lale/hyperopt_classifier.py
@@ -28,6 +28,7 @@ from typing import Optional
 import json
 import datetime
 import copy
+import sys
 
 SEED=42
 logging.basicConfig(level=logging.WARNING)
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 class HyperoptClassifier():
 
-    def __init__(self, model = None, max_evals=50, cv=5, handle_cv_failure = False, scoring='accuracy', pgo:Optional[PGO]=None):
+    def __init__(self, model = None, max_evals=50, cv=5, handle_cv_failure = False, scoring='accuracy', max_opt_time=None, pgo:Optional[PGO]=None):
         """ Instantiate the HyperoptClassifier that will use the given model and other parameters to select the 
         best performing trainable instantiation of the model. This optimizer uses negation of accuracy_score 
         as the performance metric to be minimized by Hyperopt.
@@ -68,6 +69,9 @@ class HyperoptClassifier():
             The metric has to return a scalar value, and note that scikit-learns's scorer object always returns values such that
             higher score is better. Since Hyperopt solves a minimization problem, we negate the score value to pass to Hyperopt.
             by default 'accuracy'.
+        max_opt_time : float, optional
+            Maximum amout of time in seconds for the optimization. By default, None, implying no runtime
+            bound.
         pgo : Optional[PGO], optional
             [description], by default None
         
@@ -103,9 +107,11 @@ class HyperoptClassifier():
         self.handle_cv_failure = handle_cv_failure
         self.cv = cv
         self.trials = Trials()
+        self.max_opt_time = max_opt_time
 
 
     def fit(self, X_train, y_train):
+        opt_start_time = time.time()
 
         def hyperopt_train_test(params, X_train, y_train):
             warnings.filterwarnings("ignore")
@@ -142,6 +148,11 @@ class HyperoptClassifier():
             return clf
 
         def f(params):
+            current_time = time.time()
+            if (self.max_opt_time is not None) and ((current_time - opt_start_time) > self.max_opt_time) :
+                # if max optimization time set, and we have crossed it, exit optimization completely
+                sys.exit(0)
+
             params_to_save = copy.deepcopy(params)
             return_dict = {}
             try:
@@ -152,10 +163,19 @@ class HyperoptClassifier():
                 return_dict = {'status': STATUS_FAIL}
             return return_dict
 
-        fmin(f, self.search_space, algo=tpe.suggest, max_evals=self.max_evals, trials=self.trials, rstate=np.random.RandomState(SEED))
-        best_params = space_eval(self.search_space, self.trials.argmin)
-        logger.info('best accuracy: {:.1%}\nbest hyperparams found using {} hyperopt trials: {}'.format(-1*self.trials.average_best_error(), self.max_evals, best_params))
-        trained_clf = get_final_trained_clf(best_params, X_train, y_train)
+        try :
+            fmin(f, self.search_space, algo=tpe.suggest, max_evals=self.max_evals, trials=self.trials, rstate=np.random.RandomState(SEED))
+        except SystemExit :
+            logger.warning('Maximum alloted optimization time exceeded. Optimization exited prematurely')
+
+        try :
+            best_params = space_eval(self.search_space, self.trials.argmin)
+            logger.info('best accuracy: {:.1%}\nbest hyperparams found using {} hyperopt trials: {}'.format(-1*self.trials.average_best_error(), self.max_evals, best_params))
+            trained_clf = get_final_trained_clf(best_params, X_train, y_train)
+
+        except BaseException as e :
+            logger.warning('Unable to extract the best parameters from optimization, the error: {}'.format(e))
+            trained_clf = None
 
         return trained_clf
 

--- a/lale/lib/lale/hyperopt_regressor.py
+++ b/lale/lib/lale/hyperopt_regressor.py
@@ -102,6 +102,7 @@ class HyperoptRegressor():
             best_params = space_eval(self.search_space, self.trials.argmin)
             logger.info('best accuracy: {:.1%}\nbest hyperparams found using {} hyperopt trials: {}'.format(-1*self.trials.average_best_error(), self.max_evals, best_params))
             trained_reg = get_final_trained_reg(best_params, X_train, y_train)
+            self.best_model = trained_reg
         except BaseException as e :
             logger.warning('Unable to extract the best parameters from optimization, the error: {}'.format(e))
             trained_reg = None
@@ -112,11 +113,11 @@ class HyperoptRegressor():
     def predict(self, X_eval):
         import warnings
         warnings.filterwarnings("ignore")
-        reg = self.model
+        reg = self.best_model
         try:
             predictions = reg.predict(X_eval)
         except ValueError as e:
-            logger.warning("ValueError in predicting using classifier:{}, the error is:{}".format(reg, e))
+            logger.warning("ValueError in predicting using regressor:{}, the error is:{}".format(reg, e))
             predictions = None
 
         return predictions

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -199,6 +199,8 @@ class TestHyperoptClassifier(unittest.TestCase):
         clf = HyperoptClassifier(lr, scoring='accuracy', cv = 5, max_evals = 2)
         trained = clf.fit(self.X_train, self.y_train)
         predictions = trained.predict(self.X_test)
+        predictions_1 = clf.predict(self.X_test)
+        assert np.array_equal(predictions_1, predictions)
 
     def test_custom_scoring(self):
         from sklearn.metrics import f1_score, make_scorer
@@ -206,6 +208,8 @@ class TestHyperoptClassifier(unittest.TestCase):
         clf = HyperoptClassifier(lr, scoring=make_scorer(f1_score, average='macro'), cv = 5, max_evals=2)
         trained = clf.fit(self.X_train, self.y_train)
         predictions = trained.predict(self.X_test)
+        predictions_1 = clf.predict(self.X_test)
+        assert np.array_equal(predictions_1, predictions)
 
     def test_runtime_limit_hoc(self):
         import time


### PR DESCRIPTION
The summary of the changes
- Added a runtime limit to the hyperopt optimization to work in conjunction with the limit on the number of evaluations
- Fixed the `.predict` function for hyperopt classifier/regressor to have the expected behavior (I think)
- Handle the updated use of the `make_scorer`/`get_scorer` API for `HyperoptRegressor`

I have also added/updated the test_optimizers.py to test these changes