### PR TITLE
Move auto-wrap code to a different file to solve a circular dependenc…

### DIFF
--- a/examples/demo_aif360.ipynb
+++ b/examples/demo_aif360.ipynb
@@ -277,8 +277,9 @@
    ],
    "source": [
     "from lale.lib.lale import NoOp\n",
+    "import lale\n",
     "import lale.helpers\n",
-    "lale.helpers.wrap_imported_operators()\n",
+    "lale.wrap_imported_operators()\n",
     "planned_orig = (PCA | NoOp) >> (LR | XGBoost | SVM)\n",
     "planned_orig.visualize()"
    ]

--- a/examples/demo_grammars.ipynb
+++ b/examples/demo_grammars.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "from lale.grammar import Grammar\n",
     "from lale.operators import make_choice\n",
-    "from lale.helpers import wrap_imported_operators"
+    "from lale import wrap_imported_operators"
    ]
   },
   {

--- a/examples/demo_help_and_errors.ipynb
+++ b/examples/demo_help_and_errors.ipynb
@@ -19,8 +19,9 @@
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LogisticRegression as LR\n",
+    "import lale\n",
     "import lale.helpers\n",
-    "lale.helpers.wrap_imported_operators()"
+    "lale.wrap_imported_operators()"
    ]
   },
   {

--- a/examples/docs_guide_for_sklearn_users.ipynb
+++ b/examples/docs_guide_for_sklearn_users.ipynb
@@ -225,8 +225,9 @@
     "from sklearn.decomposition import PCA\n",
     "from sklearn.tree import DecisionTreeRegressor as Tree\n",
     "from lale.lib.lale import Hyperopt\n",
+    "import lale\n",
     "import lale.helpers\n",
-    "lale.helpers.wrap_imported_operators()"
+    "lale.wrap_imported_operators()"
    ]
   },
   {
@@ -546,7 +547,7 @@
     "from lale.lib.lale import NoOp, ConcatFeatures\n",
     "from sklearn.linear_model import LinearRegression as LinReg\n",
     "from xgboost import XGBRegressor as XGBoost\n",
-    "lale.helpers.wrap_imported_operators()"
+    "lale.wrap_imported_operators()"
    ]
   },
   {
@@ -1220,7 +1221,7 @@
    ],
    "source": [
     "from sklearn.decomposition import NMF\n",
-    "lale.helpers.wrap_imported_operators()\n",
+    "lale.wrap_imported_operators()\n",
     "ipython_display(NMF.input_schema_fit())"
    ]
   },

--- a/examples/talk_2019-1105-lale.ipynb
+++ b/examples/talk_2019-1105-lale.ipynb
@@ -339,8 +339,9 @@
     "from sklearn.preprocessing import Normalizer as Norm\n",
     "from sklearn.preprocessing import OneHotEncoder as OneHot\n",
     "from sklearn.linear_model import LogisticRegression as LR\n",
+    "import lale\n",
     "import lale.helpers\n",
-    "lale.helpers.wrap_imported_operators()"
+    "lale.wrap_imported_operators()"
    ]
   },
   {
@@ -600,7 +601,7 @@
    "source": [
     "from xgboost import XGBClassifier as XGBoost\n",
     "from sklearn.svm import LinearSVC\n",
-    "lale.helpers.wrap_imported_operators()"
+    "lale.wrap_imported_operators()"
    ]
   },
   {

--- a/examples/talk_2019-1208-lale.ipynb
+++ b/examples/talk_2019-1208-lale.ipynb
@@ -265,8 +265,9 @@
     "from sklearn.svm import LinearSVC\n",
     "from lale.operators import make_pipeline, make_union\n",
     "from lale.lib.lale import Project, ConcatFeatures, NoOp\n",
+    "import lale\n",
     "import lale.helpers\n",
-    "lale.helpers.wrap_imported_operators()"
+    "lale.wrap_imported_operators()"
    ]
   },
   {

--- a/examples/talk_2020-0124-lale.ipynb
+++ b/examples/talk_2020-0124-lale.ipynb
@@ -54,7 +54,7 @@
     "from sklearn.linear_model import LogisticRegression as LR\n",
     "from sklearn.svm import LinearSVC\n",
     "from xgboost import XGBClassifier as XGBoost\n",
-    "from lale.helpers import wrap_imported_operators\n",
+    "from lale import wrap_imported_operators\n",
     "wrap_imported_operators()"
    ]
   },

--- a/lale/__init__.py
+++ b/lale/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .helpers import wrap_imported_operators
+from .operator_wrapper import wrap_imported_operators

--- a/lale/helpers.py
+++ b/lale/helpers.py
@@ -36,13 +36,11 @@ from torch.utils.data import DataLoader, TensorDataset
 import copy
 import logging
 import inspect
-import pkgutil
-import importlib
 import torch
 import h5py
 from typing import Any, Dict, List, Optional, Union
 import lale.datasets.data_schemas
-from lale.sklearn_compat import clone_op
+
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
@@ -521,29 +519,6 @@ def get_default_schema(impl):
             'hyperparams': {
                 'allOf': [arg_schemas]}}}
 
-def wrap_imported_operators():
-    from lale.operators import Operator, make_operator
-    calling_frame = inspect.stack()[1][0]
-    symtab = calling_frame.f_globals
-    for name, impl in symtab.items():
-        if inspect.isclass(impl) and not issubclass(impl, Operator):
-            module = impl.__module__.split('.')[0]
-            klass = impl.__name__
-            try:
-                m = importlib.import_module('lale.lib.' + module)
-                symtab[name] = clone_op(getattr(m, klass), name)
-                logger.info(f'Lale:Wrapped known operator:{name}')
-            except (ModuleNotFoundError, AttributeError):
-                try:
-                    m = importlib.import_module('lale.lib.autogen')
-                    symtab[name] = clone_op(getattr(m, klass), name)
-                    logger.info(f'Lale:Wrapped autogen operator:{name}')
-                except (ModuleNotFoundError, AttributeError):
-                    if hasattr(impl, 'fit') and (
-                    hasattr(impl, 'predict') or hasattr(impl, 'transform')):
-                        logger.info(f'Lale:Wrapped unkwnown operator:{name}')
-                        symtab[name] = make_operator(impl=impl, name=name)
-                    
 class val_wrapper():
     """This is used to wrap values that cause problems for hyper-optimizer backends
     lale will unwrap these when given them as the value of a hyper-parameter"""

--- a/lale/operator_wrapper.py
+++ b/lale/operator_wrapper.py
@@ -1,0 +1,32 @@
+from lale.sklearn_compat import clone_op
+from lale.operators import Operator, make_operator
+
+import logging
+import inspect
+import importlib
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+def wrap_imported_operators():
+    calling_frame = inspect.stack()[1][0]
+    symtab = calling_frame.f_globals
+    for name, impl in symtab.items():
+        if inspect.isclass(impl) and not issubclass(impl, Operator):
+            module = impl.__module__.split('.')[0]
+            klass = impl.__name__
+            try:
+                m = importlib.import_module('lale.lib.' + module)
+                symtab[name] = clone_op(getattr(m, klass), name)
+                logger.info(f'Lale:Wrapped known operator:{name}')
+            except (ModuleNotFoundError, AttributeError):
+                try:
+                    m = importlib.import_module('lale.lib.autogen')
+                    symtab[name] = clone_op(getattr(m, klass), name)
+                    logger.info(f'Lale:Wrapped autogen operator:{name}')
+                except (ModuleNotFoundError, AttributeError):
+                    if hasattr(impl, 'fit') and (
+                    hasattr(impl, 'predict') or hasattr(impl, 'transform')):
+                        logger.info(f'Lale:Wrapped unkwnown operator:{name}')
+                        symtab[name] = make_operator(impl=impl, name=name)
+      

--- a/test/test_custom_schemas.py
+++ b/test/test_custom_schemas.py
@@ -309,7 +309,7 @@ class TestWrapUnknownOps(unittest.TestCase):
         try:
             from lale.operators import make_operator, PlannedIndividualOp
             self.assertFalse(isinstance(UnknownOp, PlannedIndividualOp))
-            helpers.wrap_imported_operators()
+            lale.wrap_imported_operators()
             self.assertTrue(isinstance(UnknownOp, PlannedIndividualOp))
             self.assertEqual(UnknownOp.hyperparam_schema(),
                              self.expected_schema)

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -554,7 +554,7 @@ class TestGridSearchCV(unittest.TestCase):
         from lale.lib.lale import GridSearchCV
         warnings.simplefilter("ignore")
 
-        from lale.helpers import wrap_imported_operators
+        from lale import wrap_imported_operators
         wrap_imported_operators()
         iris = load_iris()
         parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}


### PR DESCRIPTION
…y.  Change uses of it to use the canonical path: lale.wrap_imported_operators