### PR TITLE
Changed clone to deepcopy for export_to_sklearn_pipeline

### DIFF
--- a/lale/operators.py
+++ b/lale/operators.py
@@ -2146,7 +2146,7 @@ class TrainedPipeline(TrainablePipeline[TrainedOpType], TrainedOperator):
                         sklearn_op = sink_node._impl._sklearn_model
                     else:
                         sklearn_op = sink_node._impl
-                    sklearn_op = clone(sklearn_op)
+                    sklearn_op = copy.deepcopy(sklearn_op)
                     if preds is None or len(preds) == 0:
                         return sklearn_op       
                     else:


### PR DESCRIPTION
To take care of scikit like objects which do not follow all scikit conventions.