### PR TITLE
Add 'enum' property to operators.

### DIFF
--- a/test/test_json_pretty_viz.py
+++ b/test/test_json_pretty_viz.py
@@ -47,7 +47,7 @@ class TestPrettyPrint(unittest.TestCase):
 
     def test_indiv_op_1(self):
         from lale.lib.sklearn import LogisticRegression
-        pipeline = LogisticRegression(solver='saga', C=0.9)
+        pipeline = LogisticRegression(solver=LogisticRegression.enum.solver.saga, C=0.9)
         expected = """from lale.lib.sklearn import LogisticRegression
 import lale
 lale.wrap_imported_operators()


### PR DESCRIPTION
This provides a way to get auto-generated enumerations values even if the names conflict with fields of the Operator class.