### PR TITLE
Out Scripts are Optimized in the Importing Task

### DIFF
--- a/lale/docstrings.py
+++ b/lale/docstrings.py
@@ -1,5 +1,6 @@
 import pprint
 
+
 def _indent(prefix, string, first_prefix=None):
     lines = string.splitlines()
     if lines:

--- a/lale/expressions.py
+++ b/lale/expressions.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast #see also https://greentreesnakes.readthedocs.io/
-import astunparse
+import ast  # see also https://greentreesnakes.readthedocs.io/
 import pprint
 import typing
 from typing import Any, Dict, List, Optional, Union
+
+import astunparse
 
 AstLits = (ast.Num, ast.Str, ast.List, ast.Tuple, ast.Set, ast.Dict)
 AstLit = Union[ast.Num, ast.Str, ast.List, ast.Tuple, ast.Set, ast.Dict]

--- a/lale/grammar.py
+++ b/lale/grammar.py
@@ -1,9 +1,12 @@
-from lale.operators import PlannedOperator, Operator, BasePipeline, OperatorChoice, IndividualOp
-from lale.operators import make_choice, make_pipeline, make_pipeline_graph
-from lale.lib.lale import NoOp
-from typing import Optional
-from lale.sklearn_compat import clone_op
 import random
+from typing import Optional
+
+from lale.lib.lale import NoOp
+from lale.operators import (BasePipeline, IndividualOp, Operator,
+                            OperatorChoice, PlannedOperator, make_choice,
+                            make_pipeline, make_pipeline_graph)
+from lale.sklearn_compat import clone_op
+
 
 class NonTerminal(Operator):
     """ Abstract operator for non-terminal grammar rules.

--- a/lale/json_operator.py
+++ b/lale/json_operator.py
@@ -14,12 +14,14 @@
 
 import importlib
 import inspect
-import jsonschema
 import keyword
-import lale.operators
+import logging
 import re
 from typing import Any, Dict, Optional, Tuple, cast
-import logging
+
+import jsonschema
+
+import lale.operators
 
 logger = logging.getLogger(__name__)
 

--- a/lale/operator_wrapper.py
+++ b/lale/operator_wrapper.py
@@ -1,9 +1,9 @@
-from lale.sklearn_compat import clone_op
-from lale.operators import Operator, make_operator
-
-import logging
-import inspect
 import importlib
+import inspect
+import logging
+
+from lale.operators import Operator, make_operator
+from lale.sklearn_compat import clone_op
 
 logger = logging.getLogger(__name__)
 

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -99,31 +99,33 @@ The following picture illustrates the core operator class hierarchy.
 
 """
 
-import lale.helpers
-import lale.type_checking
-from abc import abstractmethod
-import enum as enumeration
-import os
-from lale import schema2enums as enum_gen
-import pandas as pd
-import lale.datasets.data_schemas
-
-from typing import AbstractSet, Any, Callable, Dict, Generic, Iterable, Iterator, List, Tuple, TypeVar, Optional, Union, cast
-import warnings
 import copy
-from lale.util.VisitorMeta import AbstractVisitorMeta
-from lale.search.PGO import remove_defaults_dict
+import enum as enumeration
 import inspect
-from lale.schemas import Schema
-import jsonschema
-import lale.pretty_print
 import logging
+import os
 import shutil
-import lale.json_operator
-from lale.json_operator import JSON_TYPE
-from sklearn.pipeline import if_delegate_has_method
-import sklearn.base
 import time
+import warnings
+from abc import abstractmethod
+from typing import (AbstractSet, Any, Callable, Dict, Generic, Iterable,
+                    Iterator, List, Optional, Tuple, TypeVar, Union, cast)
+
+import jsonschema
+import pandas as pd
+import sklearn.base
+from sklearn.pipeline import if_delegate_has_method
+
+import lale.datasets.data_schemas
+import lale.helpers
+import lale.json_operator
+import lale.pretty_print
+import lale.type_checking
+from lale import schema2enums as enum_gen
+from lale.json_operator import JSON_TYPE
+from lale.schemas import Schema
+from lale.search.PGO import remove_defaults_dict
+from lale.util.VisitorMeta import AbstractVisitorMeta
 
 logger = logging.getLogger(__name__)
 
@@ -2029,12 +2031,12 @@ class BasePipeline(Operator, Generic[OpType]):
             return old_clf
 
     def export_to_sklearn_pipeline(self):
-        from sklearn.pipeline import make_pipeline
         from sklearn.base import clone
+        from sklearn.pipeline import FeatureUnion, make_pipeline
+
         from lale.lib.lale.concat_features import ConcatFeaturesImpl
         from lale.lib.lale.no_op import NoOpImpl
         from lale.lib.lale.relational import RelationalImpl
-        from sklearn.pipeline import FeatureUnion
 
         def convert_nested_objects(node):
             for element in dir(node):#Looking at only 1 level for now.

--- a/lale/pretty_print.py
+++ b/lale/pretty_print.py
@@ -13,21 +13,22 @@
 # limitations under the License.
 
 import ast
-import black
 import importlib
 import inspect
 import json
 import keyword
 import math
-import numpy as np
 import pprint
 import re
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
+import black
+import numpy as np
+
+import lale.expressions
 import lale.json_operator
 import lale.operators
 import lale.type_checking
-import lale.expressions
 
 JSON_TYPE = Dict[str, Any]
 _black78 = black.Mode(line_length=78)

--- a/lale/schema2enums.py
+++ b/lale/schema2enums.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import enum
 import itertools
+import logging
+from typing import (Any, Callable, Dict, Iterable, Iterator, List, Optional,
+                    Set, Tuple, Union)
 
-from typing import Any, Dict, List, Set, Iterable, Iterator, Optional, Tuple, Union, Callable
-from lale.schema_simplifier import findRelevantFields, narrowToGivenRelevantFields, simplify
+from lale.schema_simplifier import (findRelevantFields,
+                                    narrowToGivenRelevantFields, simplify)
 
 from .schema_utils import Schema, SchemaEnum
 

--- a/lale/schema_ranges.py
+++ b/lale/schema_ranges.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
-from .schema_utils import Schema, getMinimum, getMaximum, getExclusiveMinimum, getExclusiveMaximum
+from .schema_utils import (Schema, getExclusiveMaximum, getExclusiveMinimum,
+                           getMaximum, getMinimum)
+
 
 class SchemaRange(object):
     def __init__(self, minimum=None, maximum=None, exclusive_minimum=False, exclusive_maximum=False, is_integer:bool=False) -> None:

--- a/lale/schema_simplifier.py
+++ b/lale/schema_simplifier.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import itertools
+import logging
+from typing import (Any, Dict, Generic, Iterable, Iterator, List, Optional,
+                    Set, Tuple, TypeVar, Union)
+
 import jsonschema
 
 from .schema_ranges import SchemaRange
-
-from typing import Any, Dict, Generic, List, Set, Iterable, Iterator, Optional, Tuple, TypeVar, Union
-from .schema_utils import Schema, getMinimum, getMaximum, isForOptimizer, makeAllOf, makeAnyOf, makeOneOf, forOptimizer, STrue, SFalse, is_true_schema, is_false_schema, is_lale_any_schema
+from .schema_utils import (Schema, SFalse, STrue, forOptimizer, getMaximum,
+                           getMinimum, is_false_schema, is_lale_any_schema,
+                           is_true_schema, isForOptimizer, makeAllOf,
+                           makeAnyOf, makeOneOf)
 
 logger = logging.getLogger(__name__)
 

--- a/lale/schema_utils.py
+++ b/lale/schema_utils.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Set, Iterable, Iterator, Optional, Tuple, Union, Callable
+from typing import (Any, Callable, Dict, Iterable, Iterator, List, Optional,
+                    Set, Tuple, Union)
 
 # Type definitions
 Schema = Any

--- a/lale/schemas.py
+++ b/lale/schemas.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, TypeVar, Any, Dict, List, Tuple, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union, cast
 
 
 class Undefined():

--- a/lale/sklearn_compat.py
+++ b/lale/sklearn_compat.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Iterable, Optional, List, Set, Tuple, TypeVar, Union
-import random
 import math
+import random
 import warnings
+from typing import (Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar,
+                    Union)
 
 import lale.operators as Ops
 from lale.pretty_print import hyperparams_to_string

--- a/lale/type_checking.py
+++ b/lale/type_checking.py
@@ -31,18 +31,21 @@ as the right side succeed. This is specified using ``{'laleType': 'Any'}``.
 """
 
 import functools
+import inspect
+import logging
+import os
+from typing import Any, Dict, List, Union
+
 import jsonschema
 import jsonschema.exceptions
 import jsonschema.validators
 import jsonsubschema
-import lale.helpers
 import numpy as np
-import os
 import pandas as pd
 import scipy.sparse
-import logging
-import inspect
-from typing import Any, Dict, List, Union
+
+import lale.helpers
+
 JSON_TYPE = Dict[str, Any]
 
 def _validate_lale_type(validator, laleType, instance, schema):
@@ -54,8 +57,9 @@ def _validate_lale_type(validator, laleType, instance, schema):
             yield jsonschema.exceptions.ValidationError(
                 f'expected {laleType}, got {type(instance)}')
     elif laleType == 'operator':
-        import lale.operators
         import sklearn.base
+
+        import lale.operators
         if not (isinstance(instance, lale.operators.Operator) or
                 isinstance(instance, sklearn.base.BaseEstimator) or
                 ( inspect.isclass(instance) and

--- a/lale/visualize.py
+++ b/lale/visualize.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import graphviz
-import lale.json_operator
-import lale.pretty_print
 import re
 from typing import Any, Dict, List, Optional, Tuple
+
+import graphviz
+
+import lale.json_operator
+import lale.pretty_print
+
 
 def _get_cluster2reps(jsn) -> Tuple[Dict[str, str], Dict[str, str]]:
     """For each cluster (Pipeline, OperatorChoice, or higher-order IndividualOp), get two representatives (first-order IndividualOps).


### PR DESCRIPTION
`isort` module observed on the outer scripts. So that neither `search/*.py`, `lib/*.py`, `datasets/*.py`, and `utils/*.py` have been changed which means that the `schema2search_space.py` file is still like the usual.