### PR TITLE
Replace pai4sk with new publicly available snapml package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     # This should run only on the master branch of the main repo
     if: github.repository == 'IBM/lale' && github.ref == 'refs/heads/master' && success()
-    needs: [static, test_matrix, test_snapml, test_notebooks]
+    needs: [static, test_matrix, test_notebooks]
     strategy:
       matrix:
         python-version: [3.6]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
         - test/test_autoai_output_consumption.py
         - test/test_autogen_lib.py
         - test/test_relational.py
+        - test/test_snapml.py
         python-version: [3.6]
         setup-target: ['.[full,test]']
         include:
@@ -127,57 +128,6 @@ jobs:
     - name: Upload coverage metrics to CodeCov
       uses: codecov/codecov-action@v1
 
-  test_snapml:
-    name: Test Snap ML
-    runs-on: ubuntu-latest
-    needs: [static]
-    strategy:
-      fail-fast: false
-      matrix:
-        test-case: [test/test_snap_ml.py]
-        python-version: [3.6]
-        setup-target: ['.[full,test]']
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install system packages
-      run: sudo apt-get install graphviz swig
-    - name: Cache conda
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if setup.py has not changed
-        CACHE_NUMBER: 0
-      with:
-        path: ~/conda_pkgs_dir
-        key:
-          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-          hashFiles('setup.py') }}
-    - name: Setup anoconda
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
-        channels: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/'
-        activate-environment: conda-snapml-env
-    - name: Install numpy
-      shell: bash -l {0}
-      run: pip install -U numpy
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: pip install --upgrade --upgrade-strategy eager ${{matrix.setup-target}}
-    - name: Install SnapML
-      shell: bash -l {0}
-      run: |
-          $CONDA/bin/conda config --set always_yes yes --set changeps1 no
-          export IBM_POWERAI_LICENSE_ACCEPT=yes
-          conda install pai4sk
-    - name: Run Test
-      shell: bash -l {0}
-      run: |
-          conda install pytest
-          py.test -v --capture=tee-sys --cov-report=xml --cov=lale ${{matrix.test-case}}
-          bash <(curl -s https://codecov.io/bash)
-    - name: Upload coverage metrics to CodeCov
-      uses: codecov/codecov-action@v1
   test_notebooks:
     name: Test Notebooks
     needs: [static]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Operator libraries
 * `lale.lib.autogen`_ auto-generated based on `scikit-learn`_
 * `lale.lib.imblearn`_ based on `imbalanced-learn`_
 * `lale.lib.lightgbm`_ based on `LightGBM`_
-* `lale.lib.pai4sk`_ based on `Snap ML`_
+* `lale.lib.snapml`_ based on `Snap ML`_
 * `lale.lib.pytorch`_ based on `PyTorch`_
 * `lale.lib.spacy`_ based on `spaCy`_
 * `lale.lib.tensorflow`_ based on `TensorFlow`_
@@ -61,7 +61,7 @@ Operator libraries
 .. _`imbalanced-learn`: https://imbalanced-learn.readthedocs.io/en/stable/index.html
 .. _`lale.lib.lightgbm`: modules/lale.lib.lightgbm.html#module-lale.lib.lightgbm
 .. _`LightGBM`: https://lightgbm.readthedocs.io/en/latest/Python-API.html
-.. _`lale.lib.pai4sk`: modules/lale.lib.pai4sk.html#module-lale.lib.pai4sk
+.. _`lale.lib.snapml`: modules/lale.lib.snapml.html#module-lale.lib.snapml
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 .. _`lale.lib.pytorch`: modules/lale.lib.pytorch.html#module-lale.lib.pytorch
 .. _`PyTorch`: https://pytorch.org/

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 IBM Corporation
+# Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@ Operators
 
 Classifiers:
 
-* lale.lib.pai4sk. `DecisionTreeClassifier`_
-* lale.lib.pai4sk. `RandomForestClassifier`_
-* lale.lib.pai4sk. `RandomForestRegressor`_
+* lale.lib.snapml. `DecisionTreeClassifier`_
+* lale.lib.snapml. `RandomForestClassifier`_
+* lale.lib.snapml. `RandomForestRegressor`_
 
-.. _`DecisionTreeClassifier`: lale.lib.pai4sk.decision_tree_classifier.html
-.. _`RandomForestClassifier`: lale.lib.pai4sk.random_forest_classifier.html
-.. _`RandomForestRegressor`: lale.lib.pai4sk.random_forest_regressor.html
+.. _`DecisionTreeClassifier`: lale.lib.snapml.decision_tree_classifier.html
+.. _`RandomForestClassifier`: lale.lib.snapml.random_forest_classifier.html
+.. _`RandomForestRegressor`: lale.lib.snapml.random_forest_regressor.html
 """
 
 from .decision_tree_classifier import DecisionTreeClassifier

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2020,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lale/lib/snapml/decision_tree_classifier.py
+++ b/lale/lib/snapml/decision_tree_classifier.py
@@ -277,7 +277,7 @@ _input_predict_schema = {
                 "items": {"type": "number"},
             },
         },
-        "num_threads": {
+        "n_jobs": {
             "type": "integer",
             "minimum": 0,
             "default": 0,
@@ -307,7 +307,7 @@ _input_predict_proba_schema = {
                 "items": {"type": "number"},
             },
         },
-        "num_threads": {
+        "n_jobs": {
             "type": "integer",
             "minimum": 0,
             "default": 0,

--- a/lale/lib/snapml/decision_tree_classifier.py
+++ b/lale/lib/snapml/decision_tree_classifier.py
@@ -45,7 +45,7 @@ class DecisionTreeClassifierImpl:
     ):
         assert (
             snapml_installed
-        ), """Your Python environment does not have snapml installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
+        ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
         self._hyperparams = {
             "criterion": criterion,
             "splitter": splitter,

--- a/lale/lib/snapml/decision_tree_classifier.py
+++ b/lale/lib/snapml/decision_tree_classifier.py
@@ -11,63 +11,56 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import TYPE_CHECKING
 
 try:
-    import pai4sk  # type: ignore
+    import snapml  # type: ignore
 
-    pai4sk_installed = True
+    snapml_installed = True
 except ImportError:
-    pai4sk_installed = False
+    snapml_installed = False
     if TYPE_CHECKING:
-        import pai4sk  # type: ignore
-
+        import snapml  # type: ignore
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
 
-class RandomForestRegressorImpl:
+class DecisionTreeClassifierImpl:
     def __init__(
         self,
-        n_estimators=10,
-        criterion="mse",
+        criterion="gini",
+        splitter="best",
         max_depth=None,
         min_samples_leaf=1,
-        max_features="auto",
-        bootstrap=True,
-        n_jobs=None,
+        max_features=None,
         random_state=None,
-        verbose=False,
+        n_jobs=1,
         use_histograms=False,
         hist_nbins=256,
         use_gpu=False,
-        gpu_ids=None,
+        gpu_id=0,
+        verbose=False,
     ):
         assert (
-            pai4sk_installed
-        ), """Your Python environment does not have pai4sk installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
+            snapml_installed
+        ), """Your Python environment does not have snapml installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
         self._hyperparams = {
-            "n_estimators": n_estimators,
             "criterion": criterion,
+            "splitter": splitter,
             "max_depth": max_depth,
             "min_samples_leaf": min_samples_leaf,
             "max_features": max_features,
-            "bootstrap": bootstrap,
-            "n_jobs": n_jobs,
             "random_state": random_state,
-            "verbose": verbose,
+            "n_jobs": n_jobs,
             "use_histograms": use_histograms,
             "hist_nbins": hist_nbins,
             "use_gpu": use_gpu,
-            "gpu_ids": gpu_ids,
+            "gpu_id": gpu_id,
+            "verbose": verbose,
         }
-        modified_hps = {**self._hyperparams}
-        if modified_hps["gpu_ids"] is None:
-            modified_hps["gpu_ids"] = [0]  # TODO: support list as default
-        self._wrapped_model = pai4sk.RandomForestRegressor(**modified_hps)
+        self._wrapped_model = snapml.DecisionTreeClassifier(**self._hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)
@@ -82,6 +75,13 @@ class RandomForestRegressorImpl:
         else:
             return self._wrapped_model.predict(X, **predict_params)
 
+    def predict_proba(self, X, **predict_proba_params):
+        X = lale.datasets.data_schemas.strip_schema(X)
+        if predict_proba_params is None:
+            return self._wrapped_model.predict_proba(X)
+        else:
+            return self._wrapped_model.predict_proba(X, **predict_proba_params)
+
 
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
@@ -90,27 +90,23 @@ _hyperparams_schema = {
             "description": "This first sub-object lists all constructor arguments with their types, one at a time, omitting cross-argument constraints.",
             "type": "object",
             "relevantToOptimizer": [
-                "n_estimators",
                 "criterion",
+                "splitter",
                 "max_depth",
                 "min_samples_leaf",
                 "max_features",
-                "bootstrap",
             ],
             "additionalProperties": False,
             "properties": {
-                "n_estimators": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "minimumForOptimizer": 10,
-                    "maximumForOptimizer": 100,
-                    "default": 10,
-                    "description": "The number of trees in the forest.",
-                },
                 "criterion": {
-                    "enum": ["mse"],
-                    "default": "mse",
+                    "enum": ["gini"],
+                    "default": "gini",
                     "description": "Function to measure the quality of a split.",
+                },
+                "splitter": {
+                    "enum": ["best"],
+                    "default": "best",
+                    "description": "The strategy used to choose the split at each node.",
                 },
                 "max_depth": {
                     "anyOf": [
@@ -168,23 +164,6 @@ _hyperparams_schema = {
                     "default": "auto",
                     "description": "The number of features to consider when looking for the best split.",
                 },
-                "bootstrap": {
-                    "type": "boolean",
-                    "default": True,
-                    "description": "Whether bootstrap samples are used when building trees.",
-                },
-                "n_jobs": {
-                    "anyOf": [
-                        {"description": "1 process.", "enum": [None]},
-                        {
-                            "description": "Number of CPU cores.",
-                            "type": "integer",
-                            "minimum": 1,
-                        },
-                    ],
-                    "default": None,
-                    "description": "Number of jobs to run in parallel for fit.",
-                },
                 "random_state": {
                     "description": "Seed of pseudo-random number generator.",
                     "anyOf": [
@@ -196,10 +175,11 @@ _hyperparams_schema = {
                     ],
                     "default": None,
                 },
-                "verbose": {
-                    "type": "boolean",
-                    "default": False,
-                    "description": "If True, it prints debugging information while training. Warning: this will increase the training time. For performance evaluation, use verbose=False.",
+                "n_jobs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "Number of CPU threads to use.",
                 },
                 "use_histograms": {
                     "type": "boolean",
@@ -216,13 +196,15 @@ _hyperparams_schema = {
                     "default": False,
                     "description": "Use GPU acceleration (only supported for histogram-based splits).",
                 },
-                "gpu_ids": {
-                    "anyOf": [
-                        {"description": "Use [0].", "enum": [None]},
-                        {"type": "array", "items": {"type": "integer"}},
-                    ],
-                    "default": None,
-                    "description": "Device IDs of the GPUs which will be used when GPU acceleration is enabled.",
+                "gpu_id": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Device ID of the GPU which will be used when GPU acceleration is enabled.",
+                },
+                "verbose": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "If True, it prints debugging information while training. Warning: this will increase the training time. For performance evaluation, use verbose=False.",
                 },
             },
         },
@@ -234,10 +216,17 @@ _hyperparams_schema = {
             ],
         },
         {
-            "description": "Only need gpu_ids when use_gpu is true.",
+            "description": "GPU only supported for histogram-based splits.",
+            "anyOf": [
+                {"type": "object", "properties": {"use_histograms": {"enum": [True]}}},
+                {"type": "object", "properties": {"use_histograms": {"enum": [False]}}},
+            ],
+        },
+        {
+            "description": "Only need gpu_id when use_gpu is true.",
             "anyOf": [
                 {"type": "object", "properties": {"use_gpu": {"enum": [True]}}},
-                {"type": "object", "properties": {"gpu_ids": {"enum": [None]}}},
+                {"type": "object", "properties": {"gpu_id": {"enum": [0]}}},
             ],
         },
     ],
@@ -306,27 +295,60 @@ _output_predict_schema = {
     ],
 }
 
+_input_predict_proba_schema = {
+    "type": "object",
+    "properties": {
+        "X": {
+            "type": "array",
+            "description": "The outer array is over samples aka rows.",
+            "items": {
+                "type": "array",
+                "description": "The inner array is over features aka columns.",
+                "items": {"type": "number"},
+            },
+        },
+        "num_threads": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of threads used to run inference. By default inference runs with maximum number of available threads..",
+        },
+    },
+}
+
+_output_predict_proba_schema = {
+    "type": "array",
+    "description": "The outer array is over samples aka rows.",
+    "items": {
+        "type": "array",
+        "description": "The inner array has items corresponding to each class.",
+        "items": {"type": "number"},
+    },
+}
+
 _combined_schemas = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": """`Random forest regressor`_ from `Snap ML`_. It can be used for binary classification problems.
+    "description": """`Decision tree classifier`_ from `Snap ML`_. It can be used for binary classification problems.
 
-.. _`Random forest regressor`: https://ibmsoe.github.io/snap-ml-doc/v1.6.0/ranforapidoc.html
+.. _`Decision tree classifier`: https://ibmsoe.github.io/snap-ml-doc/v1.6.0/dectreeapidoc.html
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 """,
-    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.pai4sk.random_forest_regressor.html",
-    "import_from": "pai4sk",
+    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.snapml.random_forest_classifier.html",
+    "import_from": "snapml",
     "type": "object",
-    "tags": {"pre": [], "op": ["estimator", "regressor"], "post": []},
+    "tags": {"pre": [], "op": ["estimator", "classifier"], "post": []},
     "properties": {
         "hyperparams": _hyperparams_schema,
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 
-lale.docstrings.set_docstrings(RandomForestRegressorImpl, _combined_schemas)
+lale.docstrings.set_docstrings(DecisionTreeClassifierImpl, _combined_schemas)
 
-RandomForestRegressor = lale.operators.make_operator(
-    RandomForestRegressorImpl, _combined_schemas
+DecisionTreeClassifier = lale.operators.make_operator(
+    DecisionTreeClassifierImpl, _combined_schemas
 )

--- a/lale/lib/snapml/decision_tree_classifier.py
+++ b/lale/lib/snapml/decision_tree_classifier.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IBM Corporation
+# Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lale/lib/snapml/random_forest_classifier.py
+++ b/lale/lib/snapml/random_forest_classifier.py
@@ -47,7 +47,7 @@ class RandomForestClassifierImpl:
     ):
         assert (
             snapml_installed
-        ), """Your Python environment does not have snapml installed. Install using: pip install snapml""
+        ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
         self._hyperparams = {
             "n_estimators": n_estimators,
             "criterion": criterion,

--- a/lale/lib/snapml/random_forest_classifier.py
+++ b/lale/lib/snapml/random_forest_classifier.py
@@ -11,56 +11,62 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import TYPE_CHECKING
 
 try:
-    import pai4sk  # type: ignore
+    import snapml  # type: ignore
 
-    pai4sk_installed = True
+    snapml_installed = True
 except ImportError:
-    pai4sk_installed = False
+    snapml_installed = False
     if TYPE_CHECKING:
-        import pai4sk  # type: ignore
+        import snapml  # type: ignore
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
 
-class DecisionTreeClassifierImpl:
+class RandomForestClassifierImpl:
     def __init__(
         self,
+        n_estimators=10,
         criterion="gini",
-        splitter="best",
         max_depth=None,
         min_samples_leaf=1,
-        max_features=None,
+        max_features="auto",
+        bootstrap=True,
+        n_jobs=1,
         random_state=None,
-        n_threads=1,
+        verbose=False,
         use_histograms=False,
         hist_nbins=256,
         use_gpu=False,
-        gpu_id=0,
-        verbose=False,
+        gpu_ids=None,
     ):
         assert (
-            pai4sk_installed
-        ), """Your Python environment does not have pai4sk installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
+            snapml_installed
+        ), """Your Python environment does not have snapml installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
         self._hyperparams = {
+            "n_estimators": n_estimators,
             "criterion": criterion,
-            "splitter": splitter,
             "max_depth": max_depth,
             "min_samples_leaf": min_samples_leaf,
             "max_features": max_features,
+            "bootstrap": bootstrap,
+            "n_jobs": n_jobs,
             "random_state": random_state,
-            "n_threads": n_threads,
+            "verbose": verbose,
             "use_histograms": use_histograms,
             "hist_nbins": hist_nbins,
             "use_gpu": use_gpu,
-            "gpu_id": gpu_id,
-            "verbose": verbose,
+            "gpu_ids": gpu_ids,
         }
-        self._wrapped_model = pai4sk.DecisionTreeClassifier(**self._hyperparams)
+        modified_hps = {**self._hyperparams}
+        if modified_hps["gpu_ids"] is None:
+            modified_hps["gpu_ids"] = [0]  # TODO: support list as default
+        self._wrapped_model = snapml.RandomForestClassifier(**modified_hps)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)
@@ -75,13 +81,6 @@ class DecisionTreeClassifierImpl:
         else:
             return self._wrapped_model.predict(X, **predict_params)
 
-    def predict_proba(self, X, **predict_proba_params):
-        X = lale.datasets.data_schemas.strip_schema(X)
-        if predict_proba_params is None:
-            return self._wrapped_model.predict_proba(X)
-        else:
-            return self._wrapped_model.predict_proba(X, **predict_proba_params)
-
 
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
@@ -90,23 +89,27 @@ _hyperparams_schema = {
             "description": "This first sub-object lists all constructor arguments with their types, one at a time, omitting cross-argument constraints.",
             "type": "object",
             "relevantToOptimizer": [
+                "n_estimators",
                 "criterion",
-                "splitter",
                 "max_depth",
                 "min_samples_leaf",
                 "max_features",
+                "bootstrap",
             ],
             "additionalProperties": False,
             "properties": {
+                "n_estimators": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "minimumForOptimizer": 10,
+                    "maximumForOptimizer": 100,
+                    "default": 10,
+                    "description": "The number of trees in the forest.",
+                },
                 "criterion": {
                     "enum": ["gini"],
                     "default": "gini",
                     "description": "Function to measure the quality of a split.",
-                },
-                "splitter": {
-                    "enum": ["best"],
-                    "default": "best",
-                    "description": "The strategy used to choose the split at each node.",
                 },
                 "max_depth": {
                     "anyOf": [
@@ -164,6 +167,17 @@ _hyperparams_schema = {
                     "default": "auto",
                     "description": "The number of features to consider when looking for the best split.",
                 },
+                "bootstrap": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Whether bootstrap samples are used when building trees.",
+                },
+                "n_jobs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "Number of CPU threads to use.",
+                },
                 "random_state": {
                     "description": "Seed of pseudo-random number generator.",
                     "anyOf": [
@@ -175,11 +189,10 @@ _hyperparams_schema = {
                     ],
                     "default": None,
                 },
-                "n_threads": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "default": 1,
-                    "description": "Number of CPU threads to use.",
+                "verbose": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "If True, it prints debugging information while training. Warning: this will increase the training time. For performance evaluation, use verbose=False.",
                 },
                 "use_histograms": {
                     "type": "boolean",
@@ -196,15 +209,13 @@ _hyperparams_schema = {
                     "default": False,
                     "description": "Use GPU acceleration (only supported for histogram-based splits).",
                 },
-                "gpu_id": {
-                    "type": "integer",
-                    "default": 0,
-                    "description": "Device ID of the GPU which will be used when GPU acceleration is enabled.",
-                },
-                "verbose": {
-                    "type": "boolean",
-                    "default": False,
-                    "description": "If True, it prints debugging information while training. Warning: this will increase the training time. For performance evaluation, use verbose=False.",
+                "gpu_ids": {
+                    "anyOf": [
+                        {"description": "Use [0].", "enum": [None]},
+                        {"type": "array", "items": {"type": "integer"}},
+                    ],
+                    "default": None,
+                    "description": "Device IDs of the GPUs which will be used when GPU acceleration is enabled.",
                 },
             },
         },
@@ -216,17 +227,10 @@ _hyperparams_schema = {
             ],
         },
         {
-            "description": "GPU only supported for histogram-based splits.",
-            "anyOf": [
-                {"type": "object", "properties": {"use_histograms": {"enum": [True]}}},
-                {"type": "object", "properties": {"use_histograms": {"enum": [False]}}},
-            ],
-        },
-        {
-            "description": "Only need gpu_id when use_gpu is true.",
+            "description": "Only need gpu_ids when use_gpu is true.",
             "anyOf": [
                 {"type": "object", "properties": {"use_gpu": {"enum": [True]}}},
-                {"type": "object", "properties": {"gpu_id": {"enum": [0]}}},
+                {"type": "object", "properties": {"gpu_ids": {"enum": [None]}}},
             ],
         },
     ],
@@ -295,46 +299,15 @@ _output_predict_schema = {
     ],
 }
 
-_input_predict_proba_schema = {
-    "type": "object",
-    "properties": {
-        "X": {
-            "type": "array",
-            "description": "The outer array is over samples aka rows.",
-            "items": {
-                "type": "array",
-                "description": "The inner array is over features aka columns.",
-                "items": {"type": "number"},
-            },
-        },
-        "num_threads": {
-            "type": "integer",
-            "minimum": 0,
-            "default": 0,
-            "description": "Number of threads used to run inference. By default inference runs with maximum number of available threads..",
-        },
-    },
-}
-
-_output_predict_proba_schema = {
-    "type": "array",
-    "description": "The outer array is over samples aka rows.",
-    "items": {
-        "type": "array",
-        "description": "The inner array has items corresponding to each class.",
-        "items": {"type": "number"},
-    },
-}
-
 _combined_schemas = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": """`Decision tree classifier`_ from `Snap ML`_. It can be used for binary classification problems.
+    "description": """`Random forest classifier`_ from `Snap ML`_. It can be used for binary classification problems.
 
-.. _`Decision tree classifier`: https://ibmsoe.github.io/snap-ml-doc/v1.6.0/dectreeapidoc.html
+.. _`Random forest classifier`: https://ibmsoe.github.io/snap-ml-doc/v1.6.0/ranforapidoc.html
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 """,
-    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.pai4sk.random_forest_classifier.html",
-    "import_from": "pai4sk",
+    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.snapml.random_forest_classifier.html",
+    "import_from": "snapml",
     "type": "object",
     "tags": {"pre": [], "op": ["estimator", "classifier"], "post": []},
     "properties": {
@@ -342,13 +315,11 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
-        "input_predict_proba": _input_predict_proba_schema,
-        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 
-lale.docstrings.set_docstrings(DecisionTreeClassifierImpl, _combined_schemas)
+lale.docstrings.set_docstrings(RandomForestClassifierImpl, _combined_schemas)
 
-DecisionTreeClassifier = lale.operators.make_operator(
-    DecisionTreeClassifierImpl, _combined_schemas
+RandomForestClassifier = lale.operators.make_operator(
+    RandomForestClassifierImpl, _combined_schemas
 )

--- a/lale/lib/snapml/random_forest_classifier.py
+++ b/lale/lib/snapml/random_forest_classifier.py
@@ -47,7 +47,7 @@ class RandomForestClassifierImpl:
     ):
         assert (
             snapml_installed
-        ), """Your Python environment does not have snapml installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
+        ), """Your Python environment does not have snapml installed. Install using: pip install snapml""
         self._hyperparams = {
             "n_estimators": n_estimators,
             "criterion": criterion,

--- a/lale/lib/snapml/random_forest_classifier.py
+++ b/lale/lib/snapml/random_forest_classifier.py
@@ -281,7 +281,7 @@ _input_predict_schema = {
                 "items": {"type": "number"},
             },
         },
-        "num_threads": {
+        "n_jobs": {
             "type": "integer",
             "minimum": 0,
             "default": 0,
@@ -297,6 +297,37 @@ _output_predict_schema = {
         {"type": "array", "items": {"type": "string"}},
         {"type": "array", "items": {"type": "boolean"}},
     ],
+}
+
+_input_predict_proba_schema = {
+    "type": "object",
+    "properties": {
+        "X": {
+            "type": "array",
+            "description": "The outer array is over samples aka rows.",
+            "items": {
+                "type": "array",
+                "description": "The inner array is over features aka columns.",
+                "items": {"type": "number"},
+            },
+        },
+        "n_jobs": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Number of threads used to run inference. By default inference runs with maximum number of available threads..",
+        },
+    },
+}
+
+_output_predict_proba_schema = {
+    "type": "array",
+    "description": "The outer array is over samples aka rows.",
+    "items": {
+        "type": "array",
+        "description": "The inner array has items corresponding to each class.",
+        "items": {"type": "number"},
+    },
 }
 
 _combined_schemas = {

--- a/lale/lib/snapml/random_forest_classifier.py
+++ b/lale/lib/snapml/random_forest_classifier.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IBM Corporation
+# Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lale/lib/snapml/random_forest_regressor.py
+++ b/lale/lib/snapml/random_forest_regressor.py
@@ -15,24 +15,25 @@
 from typing import TYPE_CHECKING
 
 try:
-    import pai4sk  # type: ignore
+    import snapml  # type: ignore
 
-    pai4sk_installed = True
+    snapml_installed = True
 except ImportError:
-    pai4sk_installed = False
+    snapml_installed = False
     if TYPE_CHECKING:
-        import pai4sk  # type: ignore
+        import snapml  # type: ignore
+
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
 
-class RandomForestClassifierImpl:
+class RandomForestRegressorImpl:
     def __init__(
         self,
         n_estimators=10,
-        criterion="gini",
+        criterion="mse",
         max_depth=None,
         min_samples_leaf=1,
         max_features="auto",
@@ -46,8 +47,8 @@ class RandomForestClassifierImpl:
         gpu_ids=None,
     ):
         assert (
-            pai4sk_installed
-        ), """Your Python environment does not have pai4sk installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
+            snapml_installed
+        ), """Your Python environment does not have snapml installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
         self._hyperparams = {
             "n_estimators": n_estimators,
             "criterion": criterion,
@@ -66,7 +67,7 @@ class RandomForestClassifierImpl:
         modified_hps = {**self._hyperparams}
         if modified_hps["gpu_ids"] is None:
             modified_hps["gpu_ids"] = [0]  # TODO: support list as default
-        self._wrapped_model = pai4sk.RandomForestClassifier(**modified_hps)
+        self._wrapped_model = snapml.RandomForestRegressor(**modified_hps)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)
@@ -107,8 +108,8 @@ _hyperparams_schema = {
                     "description": "The number of trees in the forest.",
                 },
                 "criterion": {
-                    "enum": ["gini"],
-                    "default": "gini",
+                    "enum": ["mse"],
+                    "default": "mse",
                     "description": "Function to measure the quality of a split.",
                 },
                 "max_depth": {
@@ -173,16 +174,10 @@ _hyperparams_schema = {
                     "description": "Whether bootstrap samples are used when building trees.",
                 },
                 "n_jobs": {
-                    "anyOf": [
-                        {"description": "1 process.", "enum": [None]},
-                        {
-                            "description": "Number of CPU cores.",
-                            "type": "integer",
-                            "minimum": 1,
-                        },
-                    ],
-                    "default": None,
-                    "description": "Number of jobs to run in parallel for fit.",
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "Number of CPU threads to use.",
                 },
                 "random_state": {
                     "description": "Seed of pseudo-random number generator.",
@@ -307,15 +302,15 @@ _output_predict_schema = {
 
 _combined_schemas = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": """`Random forest classifier`_ from `Snap ML`_. It can be used for binary classification problems.
+    "description": """`Random forest regressor`_ from `Snap ML`_. It can be used for binary classification problems.
 
-.. _`Random forest classifier`: https://ibmsoe.github.io/snap-ml-doc/v1.6.0/ranforapidoc.html
+.. _`Random forest regressor`: https://ibmsoe.github.io/snap-ml-doc/v1.6.0/ranforapidoc.html
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 """,
-    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.pai4sk.random_forest_classifier.html",
-    "import_from": "pai4sk",
+    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.snapml.random_forest_regressor.html",
+    "import_from": "snapml",
     "type": "object",
-    "tags": {"pre": [], "op": ["estimator", "classifier"], "post": []},
+    "tags": {"pre": [], "op": ["estimator", "regressor"], "post": []},
     "properties": {
         "hyperparams": _hyperparams_schema,
         "input_fit": _input_fit_schema,
@@ -324,8 +319,8 @@ _combined_schemas = {
     },
 }
 
-lale.docstrings.set_docstrings(RandomForestClassifierImpl, _combined_schemas)
+lale.docstrings.set_docstrings(RandomForestRegressorImpl, _combined_schemas)
 
-RandomForestClassifier = lale.operators.make_operator(
-    RandomForestClassifierImpl, _combined_schemas
+RandomForestRegressor = lale.operators.make_operator(
+    RandomForestRegressorImpl, _combined_schemas
 )

--- a/lale/lib/snapml/random_forest_regressor.py
+++ b/lale/lib/snapml/random_forest_regressor.py
@@ -282,7 +282,7 @@ _input_predict_schema = {
                 "items": {"type": "number"},
             },
         },
-        "num_threads": {
+        "n_jobs": {
             "type": "integer",
             "minimum": 0,
             "default": 0,

--- a/lale/lib/snapml/random_forest_regressor.py
+++ b/lale/lib/snapml/random_forest_regressor.py
@@ -48,7 +48,7 @@ class RandomForestRegressorImpl:
     ):
         assert (
             snapml_installed
-        ), """Your Python environment does not have snapml installed. For installation instructions see: https://www.zurich.ibm.com/snapml/"""
+        ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
         self._hyperparams = {
             "n_estimators": n_estimators,
             "criterion": criterion,

--- a/lale/lib/snapml/random_forest_regressor.py
+++ b/lale/lib/snapml/random_forest_regressor.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IBM Corporation
+# Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "full": [
             "xgboost",
             "lightgbm",
+            "snapml",
             "liac-arff>=2.4.0",
             "pytorch-pretrained-bert>=0.6.1",
             "torchvision>=0.2.2",

--- a/test/test_snapml.py
+++ b/test/test_snapml.py
@@ -1,4 +1,4 @@
-# Copyright 2020 IBM Corporation
+# Copyright 2020,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_snapml.py
+++ b/test/test_snapml.py
@@ -32,7 +32,7 @@ class TestSnapMLClassifiers(unittest.TestCase):
         clf = snapml.RandomForestClassifier()
         self.assertIsInstance(clf, snapml.RandomForestClassifier)
         fit_result = clf.fit(self.train_X, self.train_y)
-        #self.assertIsNone(fit_result)
+        self.assertIsInstance(fit_result, snapml.RandomForestClassifier)
         scorer = sklearn.metrics.make_scorer(sklearn.metrics.accuracy_score)
         _ = scorer(clf, self.test_X, self.test_y)
 

--- a/test/test_snapml.py
+++ b/test/test_snapml.py
@@ -27,36 +27,36 @@ class TestSnapMLClassifiers(unittest.TestCase):
         self.train_X, self.test_X, self.train_y, self.test_y = train_test_split(X, y)
 
     def test_without_lale(self):
-        import pai4sk  # type: ignore
+        import snapml  # type: ignore
 
-        clf = pai4sk.RandomForestClassifier()
-        self.assertIsInstance(clf, pai4sk.RandomForestClassifier)
+        clf = snapml.RandomForestClassifier()
+        self.assertIsInstance(clf, snapml.RandomForestClassifier)
         fit_result = clf.fit(self.train_X, self.train_y)
-        self.assertIsNone(fit_result)
+        #self.assertIsNone(fit_result)
         scorer = sklearn.metrics.make_scorer(sklearn.metrics.accuracy_score)
         _ = scorer(clf, self.test_X, self.test_y)
 
     def test_random_forest_classifier(self):
-        import lale.lib.pai4sk
+        import lale.lib.snapml
 
-        trainable = lale.lib.pai4sk.RandomForestClassifier()
+        trainable = lale.lib.snapml.RandomForestClassifier()
         trained = trainable.fit(self.train_X, self.train_y)
         scorer = sklearn.metrics.make_scorer(sklearn.metrics.accuracy_score)
         _ = scorer(trained, self.test_X, self.test_y)
 
     def test_decision_tree_classifier(self):
-        import lale.lib.pai4sk
+        import lale.lib.snapml
 
-        trainable = lale.lib.pai4sk.DecisionTreeClassifier()
+        trainable = lale.lib.snapml.DecisionTreeClassifier()
         trained = trainable.fit(self.train_X, self.train_y)
         scorer = sklearn.metrics.make_scorer(sklearn.metrics.accuracy_score)
         _ = scorer(trained, self.test_X, self.test_y)
 
     def test_sklearn_compat(self):
-        import lale.lib.pai4sk
+        import lale.lib.snapml
         import lale.sklearn_compat
 
-        trainable = lale.lib.pai4sk.RandomForestClassifier()
+        trainable = lale.lib.snapml.RandomForestClassifier()
         compat = lale.sklearn_compat.make_sklearn_compat(trainable)
         trained = compat.fit(self.train_X, self.train_y)
         scorer = sklearn.metrics.make_scorer(sklearn.metrics.accuracy_score)
@@ -72,9 +72,9 @@ class TestSnapMLRegressors(unittest.TestCase):
         self.train_X, self.test_X, self.train_y, self.test_y = train_test_split(X, y)
 
     def test_random_forest_regressor(self):
-        import lale.lib.pai4sk
+        import lale.lib.snapml
 
-        trainable = lale.lib.pai4sk.RandomForestRegressor()
+        trainable = lale.lib.snapml.RandomForestRegressor()
         trained = trainable.fit(self.train_X, self.train_y)
         scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
         _ = scorer(trained, self.test_X, self.test_y)


### PR DESCRIPTION
Snap ML is now publicly available on Windows, Linux and Mac OS via `pip install snapml`. 

This is an initial pull request to replace the existing 3 pai4sk estimators with their equivalents in the new package. 



