### PR TITLE
Adding random_state argument to fair_stratified_train_test_split

### DIFF
--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -780,7 +780,7 @@ def column_for_stratification(X, y, favorable_labels, protected_attributes):
 
 
 def fair_stratified_train_test_split(
-    X, y, favorable_labels, protected_attributes, test_size=0.25
+    X, y, favorable_labels, protected_attributes, test_size=0.25, random_state=42
 ):
     """
     Splits X and y into random train and test subsets stratified by labels and protected attributes.
@@ -821,7 +821,7 @@ def fair_stratified_train_test_split(
     """
     stratify = column_for_stratification(X, y, favorable_labels, protected_attributes)
     train_X, test_X, train_y, test_y = sklearn.model_selection.train_test_split(
-        X, y, test_size=test_size, random_state=42, stratify=stratify
+        X, y, test_size=test_size, random_state=random_state, stratify=stratify
     )
     if hasattr(X, "json_schema"):
         train_X = add_schema_adjusting_n_rows(train_X, X.json_schema)

--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -807,6 +807,28 @@ def fair_stratified_train_test_split(
 
       Features for which fairness is desired.
 
+    test_size : float or int, default=0.25
+
+      If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
+      If int, represents the absolute number of test samples.
+
+    random_state : int, RandomState instance or None, default=42
+
+      Controls the shuffling applied to the data before applying the split.
+      Pass an integer for reproducible output across multiple function calls.
+
+      - None
+
+          RandomState used by numpy.random
+
+      - numpy.random.RandomState
+
+          Use the provided random state, only affecting other users of that same random state instance.
+
+      - integer
+
+          Explicit seed.
+
     Returns
     -------
     result : tuple


### PR DESCRIPTION

Fixes #596 

In the existing implementation of `fair_stratified_train_test_split`,  there is no argument for setting `random_state` and we internally just set its value to 42 when calling scikit learn's `train_test_split.`  It will be good idea to add this argument to the `fair_stratified_train_test_split` method similar to corresponding scikit routine. 
