### PR TITLE
Added README files to lale/lib packages to point to readthedocs.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,6 +20,7 @@ cvxpy>=1.0,<=1.1.7
 fairlearn
 autoai-libs
 sphinx==2.4.4
+docutils==0.16
 m2r
 sphinx_rtd_theme
 sphinxcontrib.apidoc

--- a/lale/lib/aif360/README.md
+++ b/lale/lib/aif360/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.aif360.html#module-lale.lib.aif360

--- a/lale/lib/autoai_libs/README.md
+++ b/lale/lib/autoai_libs/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.autoai_libs.html#module-lale.lib.autoai_libs

--- a/lale/lib/imblearn/README.md
+++ b/lale/lib/imblearn/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.imblearn.html#module-lale.lib.imblearn

--- a/lale/lib/lale/README.md
+++ b/lale/lib/lale/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.lale.html#module-lale.lib.lale

--- a/lale/lib/lightgbm/README.md
+++ b/lale/lib/lightgbm/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.lightgbm.html#module-lale.lib.lightgbm

--- a/lale/lib/snapml/README.md
+++ b/lale/lib/snapml/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.snapml.html#module-lale.lib.snapml

--- a/lale/lib/xgboost/README.md
+++ b/lale/lib/xgboost/README.md
@@ -1,0 +1,1 @@
+Documentation: https://lale.readthedocs.io/en/latest/modules/lale.lib.xgboost.html#module-lale.lib.xgboost


### PR DESCRIPTION
 Also, pinned docutils version for readthedocs to get nested lists to render properly again, following this work-around: https://github.com/sphinx-doc/sphinx/issues/9065.