### PR TITLE
Contributing SpeedDating dataset from OpenML to AIF360 datasets

### DIFF
--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -517,7 +517,9 @@ experiments_dict["SpeedDating"][
 experiments_dict["SpeedDating"][
     "download_csv_url"
 ] = "https://www.openml.org/data/get_csv/13153954/speeddating.arff"
-experiments_dict["SpeedDating"]["task_type"]
+experiments_dict["SpeedDating"]["task_type"] = "classification"
+experiments_dict["SpeedDating"]["target"] = "match"
+
 
 
 def add_schemas(schema_orig, target_col, train_X, test_X, train_y, test_y):

--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -509,6 +509,16 @@ experiments_dict["ricci"][
 experiments_dict["ricci"]["task_type"] = "classification"
 experiments_dict["ricci"]["target"] = "promotion"
 
+experiments_dict["SpeedDating"] = {}
+experiments_dict["SpeedDating"]["dataset_url"] = "https://www.openml.org/d/40536"
+experiments_dict["SpeedDating"][
+    "download_arff_url"
+] = "https://www.openml.org/data/download/13153954/speeddating.arff"
+experiments_dict["SpeedDating"][
+    "download_csv_url"
+] = "https://www.openml.org/data/get_csv/13153954/speeddating.arff"
+experiments_dict["SpeedDating"]["task_type"]
+
 
 def add_schemas(schema_orig, target_col, train_X, test_X, train_y, test_y):
     from lale.datasets.data_schemas import add_schema

--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -521,7 +521,6 @@ experiments_dict["SpeedDating"]["task_type"] = "classification"
 experiments_dict["SpeedDating"]["target"] = "match"
 
 
-
 def add_schemas(schema_orig, target_col, train_X, test_X, train_y, test_y):
     from lale.datasets.data_schemas import add_schema
 

--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -87,6 +87,7 @@ Other Functions:
 * `fetch_compas_df`_
 * `fetch_creditg_df`_
 * `fetch_ricci_df`_
+* `fetch_speeddating_df`_
 
 Mitigator Patterns:
 ===================
@@ -150,6 +151,7 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_compas_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_compas_df
 .. _`fetch_creditg_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_creditg_df
 .. _`fetch_ricci_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_ricci_df
+.. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
 .. _`r2_and_disparate_impact`: lale.lib.aif360.util.html#lale.lib.aif360.util.r2_and_disparate_impact
 .. _`statistical_parity_difference`: lale.lib.aif360.util.html#lale.lib.aif360.util.statistical_parity_difference
 .. _`theil_index`: lale.lib.aif360.util.html#lale.lib.aif360.util.theil_index
@@ -164,6 +166,7 @@ from .datasets import (
     fetch_compas_df,
     fetch_creditg_df,
     fetch_ricci_df,
+    fetch_speeddating_df,
 )
 from .disparate_impact_remover import DisparateImpactRemover
 from .eq_odds_postprocessing import EqOddsPostprocessing

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -461,27 +461,28 @@ def fetch_speeddating_df(preprocess=False):
     orig_X = pd.concat([train_X, test_X]).sort_index()
     orig_y = pd.concat([train_y, test_y]).sort_index()
     if preprocess:
-        importance_same_race = pd.Series(orig_X["importance_same_race"] >= 9, dtype=np.float64)
+        importance_same_race = pd.Series(
+            orig_X["importance_same_race"] >= 9, dtype=np.float64
+        )
         samerace = pd.Series(orig_X["samerace_1"] == 1, dtype=np.float64)
-        dropped_X = orig_X.drop(labels=[
-            "samerace_0",
-            "samerace_1"
-        ], axis=1)
-        encoded_X = dropped_X.assign(samerace=samerace, importance_same_race=importance_same_race)
+        dropped_X = orig_X.drop(labels=["samerace_0", "samerace_1"], axis=1)
+        encoded_X = dropped_X.assign(
+            samerace=samerace, importance_same_race=importance_same_race
+        )
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [
                 {"feature": "samerace", "reference_group": [1]},
-                {"feature": "importance_same_race", "reference_group": [1]}
+                {"feature": "importance_same_race", "reference_group": [1]},
             ],
         }
         return encoded_X, orig_y, fairness_info
     else:
         fairness_info = {
-            "favorable_labels": ['1'],
+            "favorable_labels": ["1"],
             "protected_attributes": [
-                {"feature": "samerace", "reference_group": ['1']},
-                {"feature": "importance_same_race", "reference_group": [[9, 1000]]}
+                {"feature": "samerace", "reference_group": ["1"]},
+                {"feature": "importance_same_race", "reference_group": [[9, 1000]]},
             ],
         }
         return orig_X, orig_y, fairness_info

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -461,39 +461,16 @@ def fetch_speeddating_df(preprocess=False):
     orig_X = pd.concat([train_X, test_X]).sort_index()
     orig_y = pd.concat([train_y, test_y]).sort_index()
     if preprocess:
-        #gender = pd.Series(orig_X["gender_male"] == 1, dtype=np.float64)
-        #age = pd.Series(orig_X["age"] > 25, dtype=np.float64)
         importance_same_race = pd.Series(orig_X["importance_same_race"] >= 9, dtype=np.float64)
-        #age_o = pd.Series(orig_X["age_o"] > 25, dtype=np.float64)
-        #race = pd.Series(orig_X["race_European/Caucasian-American"] == 1, dtype=np.float64)
-        #race_o = pd.Series(orig_X["race_o_European/Caucasian-American"] == 1, dtype=np.float64)
         samerace = pd.Series(orig_X["samerace_1"] == 1, dtype=np.float64)
         dropped_X = orig_X.drop(labels=[
-            # "gender_male",
-            # "gender_female",
-            # "race_European/Caucasian-American",
-            # "race_Asian/Pacific Islander/Asian-American",
-            # "race_Other",
-            # "race_Latino/Hispanic American",
-            # "race_Black/African American",
-            # "race_o_European/Caucasian-American",
-            # "race_o_Asian/Pacific Islander/Asian-American",
-            # "race_o_Other",
-            # "race_o_Latino/Hispanic American",
-            # "race_o_Black/African American",
             "samerace_0",
             "samerace_1"
         ], axis=1)
-        # encoded_X = dropped_X.assign(gender=gender, age=age, age_o=age_o, race=race, race_o=race_o)
         encoded_X = dropped_X.assign(samerace=samerace, importance_same_race=importance_same_race)
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [
-                # {"feature": "race", "reference_group": [1]},
-                # {"feature": "gender", "reference_group": [1]},
-                # {"feature": "race_o", "reference_group": [1]},
-                # {"feature": "age", "reference_group": [1]},
-                # {"feature": "age_o", "reference_group": [1]}
                 {"feature": "samerace", "reference_group": [1]},
                 {"feature": "importance_same_race", "reference_group": [1]}
             ],
@@ -503,11 +480,6 @@ def fetch_speeddating_df(preprocess=False):
         fairness_info = {
             "favorable_labels": ['1'],
             "protected_attributes": [
-                # {"feature": "race", "reference_group": ["European/Caucasian-American"]},
-                # {"feature": "gender", "reference_group": ["male"]},
-                # {"feature": "race_o", "reference_group": ["European/Caucasian-American"]},
-                # {"feature": "age", "reference_group": [[26, 1000]]},
-                # {"feature": "age_o", "reference_group": [[26, 1000]]}
                 {"feature": "samerace", "reference_group": ['1']},
                 {"feature": "importance_same_race", "reference_group": [[9, 1000]]}
             ],

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -420,10 +420,10 @@ def fetch_speeddating_df(preprocess=False):
 
     It contains data gathered from participants in experimental speed dating events
     from 2002-2004 with a binary classification into match or no
-    match.  Without preprocessing, the dataset has 8378 rows and 123
-    columns.  There are five protected attributes, gender, age of self,
-    age of partner, race of self, and race of partner, and the
-    disparate impact is 0.50.  The data includes both categorical and
+    match.  Without preprocessing, the dataset has 8378 rows and 122
+    columns.  There are two protected attributes, whether the other candidate has the same
+    race and importance of having the same race, and the disparate impact
+    is 0.85.  The data includes both categorical and
     numeric columns, with some missing values.
 
     .. _`SpeedDating`: https://www.openml.org/d/40536
@@ -461,46 +461,55 @@ def fetch_speeddating_df(preprocess=False):
     orig_X = pd.concat([train_X, test_X]).sort_index()
     orig_y = pd.concat([train_y, test_y]).sort_index()
     if preprocess:
-        gender = pd.Series(orig_X["gender_male"] == 1, dtype=np.float64)
-        age = pd.Series(orig_X["age"] > 25, dtype=np.float64)
-        age_o = pd.Series(orig_X["age_o"] > 25, dtype=np.float64)
-        race = pd.Series(orig_X["race_European/Caucasian-American"] == 1, dtype=np.float64)
-        race_o = pd.Series(orig_X["race_o_European/Caucasian-American"] == 1, dtype=np.float64)
+        #gender = pd.Series(orig_X["gender_male"] == 1, dtype=np.float64)
+        #age = pd.Series(orig_X["age"] > 25, dtype=np.float64)
+        importance_same_race = pd.Series(orig_X["importance_same_race"] >= 9, dtype=np.float64)
+        #age_o = pd.Series(orig_X["age_o"] > 25, dtype=np.float64)
+        #race = pd.Series(orig_X["race_European/Caucasian-American"] == 1, dtype=np.float64)
+        #race_o = pd.Series(orig_X["race_o_European/Caucasian-American"] == 1, dtype=np.float64)
+        samerace = pd.Series(orig_X["samerace_1"] == 1, dtype=np.float64)
         dropped_X = orig_X.drop(labels=[
-            "gender_male",
-            "gender_female",
-            "race_European/Caucasian-American",
-            "race_Asian/Pacific Islander/Asian-American",
-            "race_Other",
-            "race_Latino/Hispanic American",
-            "race_Black/African American",
-            "race_o_European/Caucasian-American",
-            "race_o_Asian/Pacific Islander/Asian-American",
-            "race_o_Other",
-            "race_o_Latino/Hispanic American",
-            "race_o_Black/African American",
+            # "gender_male",
+            # "gender_female",
+            # "race_European/Caucasian-American",
+            # "race_Asian/Pacific Islander/Asian-American",
+            # "race_Other",
+            # "race_Latino/Hispanic American",
+            # "race_Black/African American",
+            # "race_o_European/Caucasian-American",
+            # "race_o_Asian/Pacific Islander/Asian-American",
+            # "race_o_Other",
+            # "race_o_Latino/Hispanic American",
+            # "race_o_Black/African American",
+            "samerace_0",
+            "samerace_1"
         ], axis=1)
-        encoded_X = dropped_X.assign(gender=gender, age=age, age_o=age_o, race=race, race_o=race_o)
+        # encoded_X = dropped_X.assign(gender=gender, age=age, age_o=age_o, race=race, race_o=race_o)
+        encoded_X = dropped_X.assign(samerace=samerace, importance_same_race=importance_same_race)
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [
-                {"feature": "race", "reference_group": [1]},
-                {"feature": "gender", "reference_group": [1]},
-                {"feature": "race_o", "reference_group": [1]},
-                {"feature": "age", "reference_group": [1]},
-                {"feature": "age_o", "reference_group": [1]}
+                # {"feature": "race", "reference_group": [1]},
+                # {"feature": "gender", "reference_group": [1]},
+                # {"feature": "race_o", "reference_group": [1]},
+                # {"feature": "age", "reference_group": [1]},
+                # {"feature": "age_o", "reference_group": [1]}
+                {"feature": "samerace", "reference_group": [1]},
+                {"feature": "importance_same_race", "reference_group": [1]}
             ],
         }
         return encoded_X, orig_y, fairness_info
     else:
         fairness_info = {
-            "favorable_labels": [1],
+            "favorable_labels": ['1'],
             "protected_attributes": [
-                {"feature": "race", "reference_group": ["European/Caucasian-American"]},
-                {"feature": "gender", "reference_group": ["male"]},
-                {"feature": "race_o", "reference_group": ["European/Caucasian-American"]},
-                {"feature": "age", "reference_group": [[26, 1000]]},
-                {"feature": "age_o", "reference_group": [[26, 1000]]}
+                # {"feature": "race", "reference_group": ["European/Caucasian-American"]},
+                # {"feature": "gender", "reference_group": ["male"]},
+                # {"feature": "race_o", "reference_group": ["European/Caucasian-American"]},
+                # {"feature": "age", "reference_group": [[26, 1000]]},
+                # {"feature": "age_o", "reference_group": [[26, 1000]]}
+                {"feature": "samerace", "reference_group": ['1']},
+                {"feature": "importance_same_race", "reference_group": [[9, 1000]]}
             ],
         }
         return orig_X, orig_y, fairness_info

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -413,6 +413,7 @@ def fetch_ricci_df(preprocess=False):
         }
         return orig_X, orig_y, fairness_info
 
+
 def fetch_speeddating_df(preprocess=False):
     """
     Fetch the `SpeedDating`_ dataset from OpenML and add `fairness_info`.

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -105,11 +105,11 @@ class TestAIF360Datasets(unittest.TestCase):
     
     def test_dataset_speeddating_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 8_378, 123, {0, 1}, 0.5)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 495, {0, 1}, 0.5)
 
     def test_dataset_speeddating_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 8_378, 123, {0, 1}, 0.5)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 122, {'0', '1'}, 0.5)
 
 
 class TestAIF360Num(unittest.TestCase):

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -102,14 +102,14 @@ class TestAIF360Datasets(unittest.TestCase):
     def test_dataset_ricci_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_ricci_df(preprocess=True)
         self._attempt_dataset(X, y, fairness_info, 118, 6, {0, 1}, 0.498)
-    
+
     def test_dataset_speeddating_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=True)
         self._attempt_dataset(X, y, fairness_info, 8_378, 503, {0, 1}, 0.853)
 
     def test_dataset_speeddating_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 8_378, 122, {'0', '1'}, 0.853)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 122, {"0", "1"}, 0.853)
 
 
 class TestAIF360Num(unittest.TestCase):

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -102,6 +102,14 @@ class TestAIF360Datasets(unittest.TestCase):
     def test_dataset_ricci_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_ricci_df(preprocess=True)
         self._attempt_dataset(X, y, fairness_info, 118, 6, {0, 1}, 0.498)
+    
+    def test_dataset_speeddating_pd_num(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=True)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 123, {0, 1}, 0.5)
+
+    def test_dataset_speeddating_pd_cat(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=False)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 123, {0, 1}, 0.5)
 
 
 class TestAIF360Num(unittest.TestCase):

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -105,11 +105,11 @@ class TestAIF360Datasets(unittest.TestCase):
     
     def test_dataset_speeddating_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 8_378, 495, {0, 1}, 0.5)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 503, {0, 1}, 0.853)
 
     def test_dataset_speeddating_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 8_378, 122, {'0', '1'}, 0.5)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 122, {'0', '1'}, 0.853)
 
 
 class TestAIF360Num(unittest.TestCase):


### PR DESCRIPTION
Implemented code to pull the SpeedDating dataset from OpenML (https://www.openml.org/d/40536) in `lale.lib.aif360` and wrote tests to make sure that data can be pulled successfully and that preprocessed and non-preprocessed dataframes have expected structure and disparate impact.

For now, `samerace` and `importance_same_race` are being treated as protected attributes with privileged groups of `1` and `>= 8` respectively. This results in a disparate impact of 0.85. While this is within fairness bounds for group fairness based on best practices, it should be noted that models trained with this dataset may be individually unfair based on existing literature (https://www.researchgate.net/publication/341434281_Matchmaking_Under_Fairness_Constraints_a_Speed_Dating_Case_Study).