### PR TITLE
Contributing datasets corresponding to Panels 19, 20, and 21 from years 2015 and 2016 of the MEPS dataset

### DIFF
--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -154,6 +154,7 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_ricci_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_ricci_df
 .. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
 .. _`fetch_boston_housing_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_boston_housing_df
+.. _`fetch_meps_panel19_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel19_fy2015_df
 .. _`r2_and_disparate_impact`: lale.lib.aif360.util.html#lale.lib.aif360.util.r2_and_disparate_impact
 .. _`statistical_parity_difference`: lale.lib.aif360.util.html#lale.lib.aif360.util.statistical_parity_difference
 .. _`theil_index`: lale.lib.aif360.util.html#lale.lib.aif360.util.theil_index
@@ -168,6 +169,7 @@ from .datasets import (
     fetch_boston_housing_df,
     fetch_compas_df,
     fetch_creditg_df,
+    fetch_meps_panel19_fy2015_df,
     fetch_ricci_df,
     fetch_speeddating_df,
 )

--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -89,6 +89,10 @@ Other Functions:
 * `fetch_ricci_df`_
 * `fetch_speeddating_df`_
 * `fetch_boston_housing_df`_
+* `fetch_meps_panel19_fy2015_df`_
+* `fetch_meps_panel20_fy2015_df`_
+* `fetch_meps_panel21_fy2016_df`_
+
 
 Mitigator Patterns:
 ===================
@@ -155,6 +159,8 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
 .. _`fetch_boston_housing_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_boston_housing_df
 .. _`fetch_meps_panel19_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel19_fy2015_df
+.. _`fetch_meps_panel20_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel20_fy2015_df
+.. _`fetch_meps_panel21_fy2016_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel21_fy2016_df
 .. _`r2_and_disparate_impact`: lale.lib.aif360.util.html#lale.lib.aif360.util.r2_and_disparate_impact
 .. _`statistical_parity_difference`: lale.lib.aif360.util.html#lale.lib.aif360.util.statistical_parity_difference
 .. _`theil_index`: lale.lib.aif360.util.html#lale.lib.aif360.util.theil_index
@@ -170,6 +176,8 @@ from .datasets import (
     fetch_compas_df,
     fetch_creditg_df,
     fetch_meps_panel19_fy2015_df,
+    fetch_meps_panel20_fy2015_df,
+    fetch_meps_panel21_fy2016_df,
     fetch_ricci_df,
     fetch_speeddating_df,
 )

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -15,6 +15,7 @@
 import os
 from enum import Enum
 
+import aif360
 import aif360.datasets
 import numpy as np
 import pandas as pd

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from enum import Enum
+
+import aif360.datasets
 import numpy as np
 import pandas as pd
 
 import lale.datasets
 import lale.datasets.openml
+import lale.lib.aif360.util
 
 
 def fetch_adult_df(preprocess=False):
@@ -506,9 +511,7 @@ def fetch_boston_housing_df(preprocess=False):
     preprocess : boolean, optional, default False
 
       If True,
-      encode protected attribute in X related to proportion of Blacks by town as 0 or 1
-      (0 if the proportion is above a threshold and 1 if the proportion is below)
-      to indicate privileged groups.
+      encode protected attribute in X as 0 or 1 to indicate privileged groups.
 
     Returns
     -------
@@ -555,3 +558,184 @@ def fetch_boston_housing_df(preprocess=False):
             ],
         }
         return orig_X, orig_y, fairness_info
+
+
+# MEPS HELPERS
+class FiscalYear(Enum):
+    FY2015 = 15
+    FY2016 = 16
+
+
+class Panel(Enum):
+    PANEL19 = 19
+    PANEL20 = 20
+    PANEL21 = 21
+
+
+def race(row):
+    if (row["HISPANX"] == 2) and (
+        row["RACEV2X"] == 1
+    ):  # non-Hispanic Whites are marked as WHITE; all others as NON-WHITE
+        return "White"
+    return "Non-White"
+
+
+def get_utilization_columns(fiscal_year):
+    return [
+        f"OBTOTV{fiscal_year.value}",
+        f"OPTOTV{fiscal_year.value}",
+        f"ERTOT{fiscal_year.value}",
+        f"IPNGTD{fiscal_year.value}",
+        f"HHTOTD{fiscal_year.value}",
+    ]
+
+
+def get_total_utilization(row, fiscal_year):
+    cols = get_utilization_columns(fiscal_year)
+    return sum(list(map(lambda x: row[x], cols)))
+
+
+def should_drop_column(x, fiscal_year):
+    utilization_cols = set(get_utilization_columns(fiscal_year))
+    return x in utilization_cols
+
+
+def fetch_meps_raw_df(panel, fiscal_year):
+    filename = ""
+    if fiscal_year == FiscalYear.FY2015:
+        filename = "h181.csv"
+    elif fiscal_year == FiscalYear.FY2016:
+        filename = "h192.csv"
+    else:
+        raise ValueError(f"Unexpected FiscalYear received: {fiscal_year}")
+    filepath = os.path.join(
+        os.path.dirname(os.path.abspath(aif360.__file__)),
+        "data",
+        "raw",
+        "meps",
+        filename,
+    )
+
+    try:
+        df = pd.read_csv(filepath, sep=",", na_values=[])
+    except IOError as err:
+        print("IOError: {}".format(err))
+        print("To use this class, please follow the instructions in found here:")
+        print(
+            "\n\t{}\n".format(
+                "https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps"
+            )
+        )
+        print(
+            f"\n to download and convert the data and place the final {filename} file, as-is, in the folder:"
+        )
+        print(
+            "\n\t{}\n".format(
+                os.path.abspath(
+                    os.path.join(
+                        os.path.abspath(__file__), "..", "..", "data", "raw", "meps"
+                    )
+                )
+            )
+        )
+        import sys
+
+        sys.exit(1)
+
+    df["RACEV2X"] = df.apply(lambda row: race(row), axis=1)
+    df = df.rename(columns={"RACEV2X": "RACE"})
+    df = df[df["PANEL"] == panel.value]
+
+    df["TOTEXP15"] = df.apply(
+        lambda row: get_total_utilization(row, fiscal_year), axis=1
+    )
+    lessE = df["TOTEXP15"] < 10.0
+    df.loc[lessE, "TOTEXP15"] = 0.0
+    moreE = df["TOTEXP15"] >= 10.0
+    df.loc[moreE, "TOTEXP15"] = 1.0
+
+    df = df.rename(columns={"TOTEXP15": "UTILIZATION"})
+    columns_to_drop = set(
+        filter(lambda x: should_drop_column(x, fiscal_year), df.columns.tolist())
+    )
+    df = df[sorted(set(df.columns.tolist()) - columns_to_drop, key=df.columns.get_loc)]
+    X = pd.DataFrame(
+        df, columns=list(filter(lambda x: x != "UTILIZATION", df.columns.tolist()))
+    )
+    y = pd.Series(df["UTILIZATION"], name="UTILIZATION")
+    fairness_info = {
+        "favorable_labels": [[10, 10000]],
+        "protected_attributes": [
+            {"feature": "RACE", "reference_group": ["White"]},
+        ],
+    }
+
+    return X, y, fairness_info
+
+
+def fetch_meps_panel19_fy2015_df(preprocess=False):
+    """
+    Fetch a subset of the `MEPS`_ dataset from aif360 and add fairness info.
+
+    It contains information collected on a nationally representative sample
+    of the civilian noninstitutionalized population of the United States,
+    specifically reported medical expenditures and civilian demographics.
+    This dataframe corresponds to data from panel 19 from the year 2015.
+    Without preprocessing, the dataframe contains 15830 rows and 138 columns.
+    (With preprocessing and restriction to panel 19, the dataframe contains
+    15830 rows and 138 columns.)
+    There is one protected attribute, race, and the disparate impact is 0.5.
+    The data includes only numeric columns, with no missing value.
+
+    Note: in order to use this dataset, be sure to follow the instructions
+    found in the `AIF360 documentation`_ and accept the corresponding license agreement.
+
+    .. _`MEPS`:  https://meps.ahrq.gov/mepsweb/data_stats/download_data_files_detail.jsp?cboPufNumber=HC-181
+    .. _`AIF360 documentation`: https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps
+
+    Parameters
+    ----------
+    preprocess : boolean, optional, default False
+
+      If True,
+      encode protected attribute in X corresponding to race as 0 or 1
+      to indicate privileged groups;
+      encode labels in y as 0 or 1 to indicate faborable outcomes;
+      rename columns that are panel or round-specific;
+      drop columns such as ID columns that are not relevant to the task at hand;
+      and drop rows where features are unknown.
+
+    Returns
+    -------
+    result : tuple
+
+      - item 0: pandas Dataframe
+
+          Features X, including both protected and non-protected attributes.
+
+      - item 1: pandas Series
+
+          Labels y.
+
+      - item 3: fairness_info
+
+          JSON meta-data following the format understood by fairness metrics
+          and mitigation operators in `lale.lib.aif360`.
+    """
+    if preprocess:
+        dataset = aif360.datasets.MEPSDataset19()
+        X, y = lale.lib.aif360.util.dataset_to_pandas(dataset)
+        fairness_info = {
+            "favorable_labels": [1],
+            "protected_attributes": [
+                {"feature": "RACE", "reference_group": [1]},
+            ],
+        }
+        return X, y, fairness_info
+    else:
+        return fetch_meps_raw_df(Panel.PANEL19, FiscalYear.FY2015)
+
+
+# def fetch_meps_panel20_fy2015_df(preprocess=False):
+
+# def fetch_meps_panel21_fy2016_df(preprocess=False):

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -577,7 +577,7 @@ class Panel(Enum):
     PANEL21 = 21
 
 
-def race(row):
+def _race(row):
     if (row["HISPANX"] == 2) and (
         row["RACEV2X"] == 1
     ):  # non-Hispanic Whites are marked as WHITE; all others as NON-WHITE
@@ -585,7 +585,7 @@ def race(row):
     return "Non-White"
 
 
-def get_utilization_columns(fiscal_year):
+def _get_utilization_columns(fiscal_year):
     return [
         f"OBTOTV{fiscal_year.value}",
         f"OPTOTV{fiscal_year.value}",
@@ -595,17 +595,17 @@ def get_utilization_columns(fiscal_year):
     ]
 
 
-def get_total_utilization(row, fiscal_year):
-    cols = get_utilization_columns(fiscal_year)
+def _get_total_utilization(row, fiscal_year):
+    cols = _get_utilization_columns(fiscal_year)
     return sum(list(map(lambda x: row[x], cols)))
 
 
-def should_drop_column(x, fiscal_year):
-    utilization_cols = set(get_utilization_columns(fiscal_year))
+def _should_drop_column(x, fiscal_year):
+    utilization_cols = set(_get_utilization_columns(fiscal_year))
     return x in utilization_cols
 
 
-def fetch_meps_raw_df(panel, fiscal_year):
+def _fetch_meps_raw_df(panel, fiscal_year):
     filename = ""
     if fiscal_year == FiscalYear.FY2015:
         assert panel == Panel.PANEL19 or panel == Panel.PANEL20
@@ -650,12 +650,12 @@ def fetch_meps_raw_df(panel, fiscal_year):
 
         sys.exit(1)
 
-    df["RACEV2X"] = df.apply(lambda row: race(row), axis=1)
+    df["RACEV2X"] = df.apply(lambda row: _race(row), axis=1)
     df = df.rename(columns={"RACEV2X": "RACE"})
     df = df[df["PANEL"] == panel.value]
 
     df["TOTEXP15"] = df.apply(
-        lambda row: get_total_utilization(row, fiscal_year), axis=1
+        lambda row: _get_total_utilization(row, fiscal_year), axis=1
     )
     lessE = df["TOTEXP15"] < 10.0
     df.loc[lessE, "TOTEXP15"] = 0.0
@@ -664,7 +664,7 @@ def fetch_meps_raw_df(panel, fiscal_year):
 
     df = df.rename(columns={"TOTEXP15": "UTILIZATION"})
     columns_to_drop = set(
-        filter(lambda x: should_drop_column(x, fiscal_year), df.columns.tolist())
+        filter(lambda x: _should_drop_column(x, fiscal_year), df.columns.tolist())
     )
     df = df[sorted(set(df.columns.tolist()) - columns_to_drop, key=df.columns.get_loc)]
     X = pd.DataFrame(
@@ -681,7 +681,7 @@ def fetch_meps_raw_df(panel, fiscal_year):
     return X, y, fairness_info
 
 
-def get_pandas_and_fairness_info_from_meps_dataset(dataset):
+def _get_pandas_and_fairness_info_from_meps_dataset(dataset):
     X, y = lale.lib.aif360.util.dataset_to_pandas(dataset)
     fairness_info = {
         "favorable_labels": [1],
@@ -743,9 +743,9 @@ def fetch_meps_panel19_fy2015_df(preprocess=False):
     """
     if preprocess:
         dataset = aif360.datasets.MEPSDataset19()
-        return get_pandas_and_fairness_info_from_meps_dataset(dataset)
+        return _get_pandas_and_fairness_info_from_meps_dataset(dataset)
     else:
-        return fetch_meps_raw_df(Panel.PANEL19, FiscalYear.FY2015)
+        return _fetch_meps_raw_df(Panel.PANEL19, FiscalYear.FY2015)
 
 
 def fetch_meps_panel20_fy2015_df(preprocess=False):
@@ -799,9 +799,9 @@ def fetch_meps_panel20_fy2015_df(preprocess=False):
     """
     if preprocess:
         dataset = aif360.datasets.MEPSDataset20()
-        return get_pandas_and_fairness_info_from_meps_dataset(dataset)
+        return _get_pandas_and_fairness_info_from_meps_dataset(dataset)
     else:
-        return fetch_meps_raw_df(Panel.PANEL20, FiscalYear.FY2015)
+        return _fetch_meps_raw_df(Panel.PANEL20, FiscalYear.FY2015)
 
 
 def fetch_meps_panel21_fy2016_df(preprocess=False):
@@ -855,6 +855,6 @@ def fetch_meps_panel21_fy2016_df(preprocess=False):
     """
     if preprocess:
         dataset = aif360.datasets.MEPSDataset21()
-        return get_pandas_and_fairness_info_from_meps_dataset(dataset)
+        return _get_pandas_and_fairness_info_from_meps_dataset(dataset)
     else:
-        return fetch_meps_raw_df(Panel.PANEL21, FiscalYear.FY2016)
+        return _fetch_meps_raw_df(Panel.PANEL21, FiscalYear.FY2016)

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -628,7 +628,7 @@ def fetch_meps_raw_df(panel, fiscal_year):
         df = pd.read_csv(filepath, sep=",", na_values=[])
     except IOError as err:
         logger.error("IOError: {}".format(err))
-        logger.error("To use this class, please follow the instructions in found here:")
+        logger.error("To use this class, please follow the instructions found here:")
         logger.error(
             "\n\t{}\n".format(
                 "https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps"
@@ -758,7 +758,8 @@ def fetch_meps_panel20_fy2015_df(preprocess=False):
     This dataframe corresponds to data from panel 20 from the year 2015.
     Without preprocessing, the dataframe contains 18849 rows and 1825 columns.
     (With preprocessing the dataframe contains 17570 rows and 138 columns.)
-    There is one protected attribute, race, and the disparate impact is 0.5.
+    There is one protected attribute, race, and the disparate impact is 0.493
+    if preprocessing is not applied and 0.488 if preprocessing is applied.
     The data includes numeric and categorical columns, with some missing values.
 
     Note: in order to use this dataset, be sure to follow the instructions
@@ -813,7 +814,8 @@ def fetch_meps_panel21_fy2016_df(preprocess=False):
     This dataframe corresponds to data from panel 20 from the year 2016.
     Without preprocessing, the dataframe contains 17052 rows and 1936 columns.
     (With preprocessing the dataframe contains 15675 rows and 138 columns.)
-    There is one protected attribute, race, and the disparate impact is 0.5.
+    There is one protected attribute, race, and the disparate impact is 0.462
+    if preprocessing is not applied and 0.451 if preprocessing is applied.
     The data includes numeric and categorical columns, with some missing values.
 
     Note: in order to use this dataset, be sure to follow the instructions

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -603,8 +603,10 @@ def should_drop_column(x, fiscal_year):
 def fetch_meps_raw_df(panel, fiscal_year):
     filename = ""
     if fiscal_year == FiscalYear.FY2015:
+        assert panel == Panel.PANEL19 or panel == Panel.PANEL20
         filename = "h181.csv"
     elif fiscal_year == FiscalYear.FY2016:
+        assert panel == Panel.PANEL21
         filename = "h192.csv"
     else:
         raise ValueError(f"Unexpected FiscalYear received: {fiscal_year}")
@@ -673,6 +675,17 @@ def fetch_meps_raw_df(panel, fiscal_year):
     return X, y, fairness_info
 
 
+def get_pandas_and_fairness_info_from_meps_dataset(dataset):
+    X, y = lale.lib.aif360.util.dataset_to_pandas(dataset)
+    fairness_info = {
+        "favorable_labels": [1],
+        "protected_attributes": [
+            {"feature": "RACE", "reference_group": [1]},
+        ],
+    }
+    return X, y, fairness_info
+
+
 def fetch_meps_panel19_fy2015_df(preprocess=False):
     """
     Fetch a subset of the `MEPS`_ dataset from aif360 and add fairness info.
@@ -681,11 +694,10 @@ def fetch_meps_panel19_fy2015_df(preprocess=False):
     of the civilian noninstitutionalized population of the United States,
     specifically reported medical expenditures and civilian demographics.
     This dataframe corresponds to data from panel 19 from the year 2015.
-    Without preprocessing, the dataframe contains 15830 rows and 138 columns.
-    (With preprocessing and restriction to panel 19, the dataframe contains
-    15830 rows and 138 columns.)
+    Without preprocessing, the dataframe contains 16578 rows and 1825 columns.
+    (With preprocessing the dataframe contains 15830 rows and 138 columns.)
     There is one protected attribute, race, and the disparate impact is 0.5.
-    The data includes only numeric columns, with no missing value.
+    The data includes numeric and categorical columns, with some missing values.
 
     Note: in order to use this dataset, be sure to follow the instructions
     found in the `AIF360 documentation`_ and accept the corresponding license agreement.
@@ -724,18 +736,116 @@ def fetch_meps_panel19_fy2015_df(preprocess=False):
     """
     if preprocess:
         dataset = aif360.datasets.MEPSDataset19()
-        X, y = lale.lib.aif360.util.dataset_to_pandas(dataset)
-        fairness_info = {
-            "favorable_labels": [1],
-            "protected_attributes": [
-                {"feature": "RACE", "reference_group": [1]},
-            ],
-        }
-        return X, y, fairness_info
+        return get_pandas_and_fairness_info_from_meps_dataset(dataset)
     else:
         return fetch_meps_raw_df(Panel.PANEL19, FiscalYear.FY2015)
 
 
-# def fetch_meps_panel20_fy2015_df(preprocess=False):
+def fetch_meps_panel20_fy2015_df(preprocess=False):
+    """
+    Fetch a subset of the `MEPS`_ dataset from aif360 and add fairness info.
 
-# def fetch_meps_panel21_fy2016_df(preprocess=False):
+    It contains information collected on a nationally representative sample
+    of the civilian noninstitutionalized population of the United States,
+    specifically reported medical expenditures and civilian demographics.
+    This dataframe corresponds to data from panel 20 from the year 2015.
+    Without preprocessing, the dataframe contains 18849 rows and 1825 columns.
+    (With preprocessing the dataframe contains 17570 rows and 138 columns.)
+    There is one protected attribute, race, and the disparate impact is 0.5.
+    The data includes numeric and categorical columns, with some missing values.
+
+    Note: in order to use this dataset, be sure to follow the instructions
+    found in the `AIF360 documentation`_ and accept the corresponding license agreement.
+
+    .. _`MEPS`:  https://meps.ahrq.gov/mepsweb/data_stats/download_data_files_detail.jsp?cboPufNumber=HC-181
+    .. _`AIF360 documentation`: https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps
+
+    Parameters
+    ----------
+    preprocess : boolean, optional, default False
+
+      If True,
+      encode protected attribute in X corresponding to race as 0 or 1
+      to indicate privileged groups;
+      encode labels in y as 0 or 1 to indicate faborable outcomes;
+      rename columns that are panel or round-specific;
+      drop columns such as ID columns that are not relevant to the task at hand;
+      and drop rows where features are unknown.
+
+    Returns
+    -------
+    result : tuple
+
+      - item 0: pandas Dataframe
+
+          Features X, including both protected and non-protected attributes.
+
+      - item 1: pandas Series
+
+          Labels y.
+
+      - item 3: fairness_info
+
+          JSON meta-data following the format understood by fairness metrics
+          and mitigation operators in `lale.lib.aif360`.
+    """
+    if preprocess:
+        dataset = aif360.datasets.MEPSDataset20()
+        return get_pandas_and_fairness_info_from_meps_dataset(dataset)
+    else:
+        return fetch_meps_raw_df(Panel.PANEL20, FiscalYear.FY2015)
+
+
+def fetch_meps_panel21_fy2016_df(preprocess=False):
+    """
+    Fetch a subset of the `MEPS`_ dataset from aif360 and add fairness info.
+
+    It contains information collected on a nationally representative sample
+    of the civilian noninstitutionalized population of the United States,
+    specifically reported medical expenditures and civilian demographics.
+    This dataframe corresponds to data from panel 20 from the year 2016.
+    Without preprocessing, the dataframe contains 17052 rows and 1936 columns.
+    (With preprocessing the dataframe contains 15675 rows and 138 columns.)
+    There is one protected attribute, race, and the disparate impact is 0.5.
+    The data includes numeric and categorical columns, with some missing values.
+
+    Note: in order to use this dataset, be sure to follow the instructions
+    found in the `AIF360 documentation`_ and accept the corresponding license agreement.
+
+    .. _`MEPS`:  https://meps.ahrq.gov/mepsweb/data_stats/download_data_files_detail.jsp?cboPufNumber=HC-181
+    .. _`AIF360 documentation`: https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps
+
+    Parameters
+    ----------
+    preprocess : boolean, optional, default False
+
+      If True,
+      encode protected attribute in X corresponding to race as 0 or 1
+      to indicate privileged groups;
+      encode labels in y as 0 or 1 to indicate faborable outcomes;
+      rename columns that are panel or round-specific;
+      drop columns such as ID columns that are not relevant to the task at hand;
+      and drop rows where features are unknown.
+
+    Returns
+    -------
+    result : tuple
+
+      - item 0: pandas Dataframe
+
+          Features X, including both protected and non-protected attributes.
+
+      - item 1: pandas Series
+
+          Labels y.
+
+      - item 3: fairness_info
+
+          JSON meta-data following the format understood by fairness metrics
+          and mitigation operators in `lale.lib.aif360`.
+    """
+    if preprocess:
+        dataset = aif360.datasets.MEPSDataset21()
+        return get_pandas_and_fairness_info_from_meps_dataset(dataset)
+    else:
+        return fetch_meps_raw_df(Panel.PANEL21, FiscalYear.FY2016)

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from enum import Enum
 
@@ -23,6 +24,9 @@ import pandas as pd
 import lale.datasets
 import lale.datasets.openml
 import lale.lib.aif360.util
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.ERROR)
 
 
 def fetch_adult_df(preprocess=False):
@@ -610,6 +614,7 @@ def fetch_meps_raw_df(panel, fiscal_year):
         assert panel == Panel.PANEL21
         filename = "h192.csv"
     else:
+        logger.error(f"Unexpected FiscalYear received: {fiscal_year}")
         raise ValueError(f"Unexpected FiscalYear received: {fiscal_year}")
     filepath = os.path.join(
         os.path.dirname(os.path.abspath(aif360.__file__)),
@@ -622,17 +627,17 @@ def fetch_meps_raw_df(panel, fiscal_year):
     try:
         df = pd.read_csv(filepath, sep=",", na_values=[])
     except IOError as err:
-        print("IOError: {}".format(err))
-        print("To use this class, please follow the instructions in found here:")
-        print(
+        logger.error("IOError: {}".format(err))
+        logger.error("To use this class, please follow the instructions in found here:")
+        logger.error(
             "\n\t{}\n".format(
                 "https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps"
             )
         )
-        print(
+        logger.error(
             f"\n to download and convert the data and place the final {filename} file, as-is, in the folder:"
         )
-        print(
+        logger.error(
             "\n\t{}\n".format(
                 os.path.abspath(
                     os.path.join(

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -666,7 +666,7 @@ def fetch_meps_raw_df(panel, fiscal_year):
     )
     y = pd.Series(df["UTILIZATION"], name="UTILIZATION")
     fairness_info = {
-        "favorable_labels": [[10, 10000]],
+        "favorable_labels": [1],
         "protected_attributes": [
             {"feature": "RACE", "reference_group": ["White"]},
         ],
@@ -696,7 +696,8 @@ def fetch_meps_panel19_fy2015_df(preprocess=False):
     This dataframe corresponds to data from panel 19 from the year 2015.
     Without preprocessing, the dataframe contains 16578 rows and 1825 columns.
     (With preprocessing the dataframe contains 15830 rows and 138 columns.)
-    There is one protected attribute, race, and the disparate impact is 0.5.
+    There is one protected attribute, race, and the disparate impact is 0.496
+    if preprocessing is not applied and 0.490 if preprocessing is applied.
     The data includes numeric and categorical columns, with some missing values.
 
     Note: in order to use this dataset, be sure to follow the instructions

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -179,32 +179,40 @@ class TestAIF360Datasets(unittest.TestCase):
         os.remove(os.path.join(directory, ssp_filename))
 
     def test_dataset_meps_panel19_fy2015_pd_cat(self):
-        # filename = "h181.csv"
-        # try:
-        #     csv_downloaded = self._try_download_csv(filename)
-        #     X, y, fairness_info = lale.lib.aif360.fetch_meps_panel19_fy2015_df(preprocess=False)
-        #     self._attempt_dataset(X, y, fairness_info, 16578, 1825, {0, 1}, 0.496)
-        # finally:
-        #     if csv_downloaded:
-        #         self._cleanup_meps(filename)
         X, y, fairness_info = lale.lib.aif360.fetch_meps_panel19_fy2015_df(
             preprocess=False
         )
         self._attempt_dataset(X, y, fairness_info, 16578, 1825, {0, 1}, 0.496)
 
     def test_dataset_meps_panel19_fy_2015_pd_num(self):
-        # filename = "h181.csv"
-        # try:
-        #     csv_downloaded = self._try_download_csv(filename)
-        #     X, y, fairness_info = lale.lib.aif360.fetch_meps_panel19_fy2015_df(preprocess=True)
-        #     self._attempt_dataset(X, y, fairness_info, 15830, 138, {0, 1}, 0.490)
-        # finally:
-        #     if csv_downloaded:
-        #         self._cleanup_meps(filename)
         X, y, fairness_info = lale.lib.aif360.fetch_meps_panel19_fy2015_df(
             preprocess=True
         )
         self._attempt_dataset(X, y, fairness_info, 15830, 138, {0, 1}, 0.490)
+
+    def test_dataset_meps_panel20_fy2015_pd_cat(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_meps_panel20_fy2015_df(
+            preprocess=False
+        )
+        self._attempt_dataset(X, y, fairness_info, 18849, 1825, {0, 1}, 0.493)
+
+    def test_dataset_meps_panel20_fy2015_pd_num(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_meps_panel20_fy2015_df(
+            preprocess=True
+        )
+        self._attempt_dataset(X, y, fairness_info, 17570, 138, {0, 1}, 0.488)
+
+    def test_dataset_meps_panel21_fy2016_pd_cat(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_meps_panel21_fy2016_df(
+            preprocess=False
+        )
+        self._attempt_dataset(X, y, fairness_info, 17052, 1936, {0, 1}, 0.462)
+
+    def test_dataset_meps_panel21_fy2016_pd_num(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_meps_panel21_fy2016_df(
+            preprocess=True
+        )
+        self._attempt_dataset(X, y, fairness_info, 15675, 138, {0, 1}, 0.451)
 
 
 class TestAIF360Num(unittest.TestCase):


### PR DESCRIPTION
Leveraging AIF360 and some Python utility libraries to add portions of the MEPS dataset to `lale.lib.aif360`. Specifically, AIF360 includes 
> three versions of Medical Expenditure Panel Surveys (AHRQ, 2015; 2016).

(https://arxiv.org/pdf/1810.01943.pdf), the preprocessed forms of which are returned by the corresponding Lale methods. However, when preprocessing is not desired, some functionality of AIF360 is reproduced in Lale in order read from raw data directly. (Note that even in this case, some minimal preprocessing occurs, such as formatting of the "race" feature column and target column).

A few other things worth mentioning:
1. The Lale fetching code assumes the user has downloaded the corresponding .SSP (SAS transport) files from the MEPS website, converted them to .CSV files, and placed them in a certain directory that the AIF360 package expects to find them. It also assumes the user accepts an agreement in downloading this data (which is why the code does not fetch data automatically, as in the OpenML case). More information about this process and user agreement can be found in the AIF360 documentation (here and also in code comments: https://github.com/Trusted-AI/AIF360/tree/master/aif360/data/raw/meps)
2. As a result of the above, if the corresponding machine lacks the .CSV files locally, the AIF360 tests generate the .CSV files through downloading and converting via `urllib`, `zipfile` and `pandas` respectively in a `setUpClass` method and immediately remove them once all tests are finished in a `tearDownClass` method. (If the files are found, they are used and left alone). An alternative would be to move these tests to `lale-gpl` and not undergo this procedure every time, but this was the more straightforward approach at the moment.
3. I've introduced various helper methods and objects to avoid code duplication as much as possible, but I'm open to simplifying or refactoring to something less DRY if my contributions have made the results difficult to understand.