### PR TITLE
Contributing Titanic dataset from OpenML

### DIFF
--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -520,6 +520,17 @@ experiments_dict["SpeedDating"][
 experiments_dict["SpeedDating"]["task_type"] = "classification"
 experiments_dict["SpeedDating"]["target"] = "match"
 
+experiments_dict["titanic"] = {}
+experiments_dict["titanic"]["dataset_url"] = "https://www.openml.org/d/40945"
+experiments_dict["titanic"][
+    "download_arff_url"
+] = "https://www.openml.org/data/download/16826755/phpMYEkMl"
+experiments_dict["titanic"][
+    "download_csv_url"
+] = "https://www.openml.org/data/get_csv/16826755/phpMYEkMl"
+experiments_dict["titanic"]["task_type"] = "classification"
+experiments_dict["titanic"]["target"] = "survived"
+
 
 def add_schemas(schema_orig, target_col, train_X, test_X, train_y, test_y):
     from lale.datasets.data_schemas import add_schema

--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -89,6 +89,7 @@ Other Functions:
 * `fetch_ricci_df`_
 * `fetch_speeddating_df`_
 * `fetch_boston_housing_df`_
+* `fetch_titanic_df`_
 * `fetch_meps_panel19_fy2015_df`_
 * `fetch_meps_panel20_fy2015_df`_
 * `fetch_meps_panel21_fy2016_df`_
@@ -158,6 +159,7 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_ricci_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_ricci_df
 .. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
 .. _`fetch_boston_housing_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_boston_housing_df
+.. _`fetch_titanic_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_titanic_df
 .. _`fetch_meps_panel19_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel19_fy2015_df
 .. _`fetch_meps_panel20_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel20_fy2015_df
 .. _`fetch_meps_panel21_fy2016_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel21_fy2016_df
@@ -180,6 +182,7 @@ from .datasets import (
     fetch_meps_panel21_fy2016_df,
     fetch_ricci_df,
     fetch_speeddating_df,
+    fetch_titanic_df,
 )
 from .disparate_impact_remover import DisparateImpactRemover
 from .eq_odds_postprocessing import EqOddsPostprocessing

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -245,7 +245,7 @@ def fetch_compas_df(preprocess=False):
           and mitigation operators in `lale.lib.aif360`.
     """
     (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
-        "compas", "classification", astype="pandas", preprocess=preprocess
+        "compas", "classification", astype="pandas", preprocess=False
     )
     orig_X = pd.concat([train_X, test_X]).sort_index().astype(np.float64)
     orig_y = pd.concat([train_y, test_y]).sort_index().astype(np.float64)
@@ -572,7 +572,7 @@ def fetch_titanic_df(preprocess=False):
     It contains data gathered from passengers on the Titanic with a binary classification
     into "survived" or "did not survive".  Without preprocessing, the dataset has
     1309 rows and 13 columns.  There are two protected attributes, sex and age, and the
-    disparate impact is 0.5.  The data includes both categorical and
+    disparate impact is 0.25.  The data includes both categorical and
     numeric columns, with some missing values.
 
     .. _`Titanic`: https://www.openml.org/d/40945
@@ -606,8 +606,8 @@ def fetch_titanic_df(preprocess=False):
     (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
         "titanic", "classification", astype="pandas", preprocess=preprocess
     )
-    orig_X = pd.concat([train_X, test_X]).sort_index().astype(np.float64)
-    orig_y = pd.concat([train_y, test_y]).sort_index().astype(np.float64)
+    orig_X = pd.concat([train_X, test_X]).sort_index()
+    orig_y = pd.concat([train_y, test_y]).sort_index()
     if preprocess:
         sex = pd.Series(orig_X["sex_female"] == 1, dtype=np.float64)
         age = pd.Series(orig_X["age"] <= 18, dtype=np.float64)
@@ -623,7 +623,7 @@ def fetch_titanic_df(preprocess=False):
         return encoded_X, orig_y, fairness_info
     else:
         fairness_info = {
-            "favorable_labels": [1],
+            "favorable_labels": ["1"],
             "protected_attributes": [
                 {"feature": "sex", "reference_group": ["female"]},
                 {"feature": "age", "reference_group": [[0, 18]]},

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -245,7 +245,7 @@ def fetch_compas_df(preprocess=False):
           and mitigation operators in `lale.lib.aif360`.
     """
     (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
-        "compas", "classification", astype="pandas", preprocess=False
+        "compas", "classification", astype="pandas", preprocess=preprocess
     )
     orig_X = pd.concat([train_X, test_X]).sort_index().astype(np.float64)
     orig_y = pd.concat([train_y, test_y]).sort_index().astype(np.float64)
@@ -560,6 +560,73 @@ def fetch_boston_housing_df(preprocess=False):
             "protected_attributes": [
                 # 1000(Bk - 0.63)^2 where Bk is the proportion of Blacks by town
                 {"feature": "B", "reference_group": [[0.0, black_median]]},
+            ],
+        }
+        return orig_X, orig_y, fairness_info
+
+
+def fetch_titanic_df(preprocess=False):
+    """
+    Fetch the `Titanic`_ dataset from OpenML and add `fairness_info`.
+
+    It contains data gathered from passengers on the Titanic with a binary classification
+    into "survived" or "did not survive".  Without preprocessing, the dataset has
+    1309 rows and 13 columns.  There are two protected attributes, sex and age, and the
+    disparate impact is 0.5.  The data includes both categorical and
+    numeric columns, with some missing values.
+
+    .. _`Titanic`: https://www.openml.org/d/40945
+
+    Parameters
+    ----------
+    preprocess : boolean, optional, default False
+
+      If True,
+      encode protected attributes in X as 0 or 1 to indicate privileged groups
+      and apply one-hot encoding to any remaining features in X that
+      are categorical and not protecteded attributes.
+
+    Returns
+    -------
+    result : tuple
+
+      - item 0: pandas Dataframe
+
+          Features X, including both protected and non-protected attributes.
+
+      - item 1: pandas Series
+
+          Labels y.
+
+      - item 3: fairness_info
+
+          JSON meta-data following the format understood by fairness metrics
+          and mitigation operators in `lale.lib.aif360`.
+    """
+    (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
+        "titanic", "classification", astype="pandas", preprocess=preprocess
+    )
+    orig_X = pd.concat([train_X, test_X]).sort_index().astype(np.float64)
+    orig_y = pd.concat([train_y, test_y]).sort_index().astype(np.float64)
+    if preprocess:
+        sex = pd.Series(orig_X["sex_female"] == 1, dtype=np.float64)
+        age = pd.Series(orig_X["age"] <= 18, dtype=np.float64)
+        dropped_X = orig_X.drop(labels=["sex_female", "sex_male"], axis=1)
+        encoded_X = dropped_X.assign(sex=sex, age=age)
+        fairness_info = {
+            "favorable_labels": [1],
+            "protected_attributes": [
+                {"feature": "sex", "reference_group": [1]},
+                {"feature": "age", "reference_group": [1]},
+            ],
+        }
+        return encoded_X, orig_y, fairness_info
+    else:
+        fairness_info = {
+            "favorable_labels": [1],
+            "protected_attributes": [
+                {"feature": "sex", "reference_group": ["female"]},
+                {"feature": "age", "reference_group": [[0, 18]]},
             ],
         }
         return orig_X, orig_y, fairness_info

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -139,6 +139,14 @@ class TestAIF360Datasets(unittest.TestCase):
         # TODO: consider better way of handling "set_y" parameter for regression problems
         self._attempt_dataset(X, y, fairness_info, 506, 13, set(y), 0.814)
 
+    def test_dataset_titanic_pd_cat(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_titanic_df(preprocess=False)
+        self._attempt_dataset(X, y, fairness_info, 1_309, 13, {"0", "1"}, 0.254)
+
+    def test_dataset_titanic_pd_num(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_titanic_df(preprocess=True)
+        self._attempt_dataset(X, y, fairness_info, 1_309, 2_828, {0, 1}, 0.254)
+
     @classmethod
     def _try_download_csv(self, filename):
         directory = os.path.join(


### PR DESCRIPTION
Adding some code to pull a dataset of passengers of the Titanic hosted on OpenML (https://www.openml.org/d/40945). The data can be used in a classification problem to predict which passengers survived, and given that women and children were given lifeboat priority, the dataset has quite noticeable disparate impact.

Note that another version of the Titanic dataset exists in OpenML with more runs (https://www.openml.org/d/40704), but the one used here has more features (and therefore may be better from a pipeline/processing standpoint). Also note that a `name` column results in a large dataframe when `preprocess=True` due to one-hot encoding. We may want to consider dropping that column in all cases if such data isn't useful in any circumstances.