### PR TITLE
Changes to COMPAS data pull code to respect user input

### DIFF
--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -245,16 +245,25 @@ def fetch_compas_df(preprocess=False):
           and mitigation operators in `lale.lib.aif360`.
     """
     (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
-        "compas", "classification", astype="pandas", preprocess=False
+        "compas", "classification", astype="pandas", preprocess=preprocess
     )
     orig_X = pd.concat([train_X, test_X]).sort_index().astype(np.float64)
     orig_y = pd.concat([train_y, test_y]).sort_index().astype(np.float64)
     if preprocess:
-        race = pd.Series(orig_X["race_caucasian"] == 1, dtype=np.float64)
+        race = pd.Series(orig_X["race_caucasian_1"] == 1, dtype=np.float64)
+        sex = pd.Series(orig_X["sex_1"] == 1, dtype=np.float64)
         dropped_X = orig_X.drop(
-            labels=["race_african-american", "race_caucasian"], axis=1
+            labels=[
+                "race_african-american_1",
+                "race_caucasian_1",
+                "race_african-american_0",
+                "race_caucasian_0",
+                "sex_1",
+                "sex_0",
+            ],
+            axis=1,
         )
-        encoded_X = dropped_X.assign(race=race)
+        encoded_X = dropped_X.assign(race=race, sex=sex)
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -97,11 +97,11 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_compas_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 5_278, 13, {0, 1}, 0.919)
+        self._attempt_dataset(X, y, fairness_info, 6_172, 51, {0, 1}, 0.954)
 
     def test_dataset_compas_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 5_278, 15, {0, 1}, 0.919)
+        self._attempt_dataset(X, y, fairness_info, 6_167, 401, {0, 1}, 0.954)
 
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -101,7 +101,7 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_compas_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 5_278, 12, {0, 1}, 0.919)
+        self._attempt_dataset(X, y, fairness_info, 5_278, 15, {0, 1}, 0.919)
 
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)


### PR DESCRIPTION
I noticed that the code used to pull COMPAS from OpenML has `preprocess=False` as a hard-coded parameter in the `fetch` method regardless of user input in `fetch_compas_df` (see diff or https://github.com/IBM/lale/blob/master/lale/lib/aif360/datasets.py#L248). This pull request respects the user's `preprocess` argument (if provided) and updates tests accordingly.

(Feel free to decline if there is currently a reason for doing this.)