### PR TITLE
Obtaining COMPAS recidivism and violent recidivism datasets from GitHub

### DIFF
--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -85,6 +85,7 @@ Other Functions:
 * `fetch_adult_df`_
 * `fetch_bank_df`_
 * `fetch_compas_df`_
+* `fetch_compas_violent_df`_
 * `fetch_creditg_df`_
 * `fetch_ricci_df`_
 * `fetch_speeddating_df`_
@@ -154,6 +155,7 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_adult_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_adult_df
 .. _`fetch_bank_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_bank_df
 .. _`fetch_compas_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_compas_df
+.. _`fetch_compas_violent_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_compas_violent_df
 .. _`fetch_creditg_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_creditg_df
 .. _`fetch_ricci_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_ricci_df
 .. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
@@ -174,6 +176,7 @@ from .datasets import (
     fetch_bank_df,
     fetch_boston_housing_df,
     fetch_compas_df,
+    fetch_compas_violent_df,
     fetch_creditg_df,
     fetch_meps_panel19_fy2015_df,
     fetch_meps_panel20_fy2015_df,

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -245,16 +245,25 @@ def fetch_compas_df(preprocess=False):
           and mitigation operators in `lale.lib.aif360`.
     """
     (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
-        "compas", "classification", astype="pandas", preprocess=False
+        "compas", "classification", astype="pandas", preprocess=preprocess
     )
     orig_X = pd.concat([train_X, test_X]).sort_index().astype(np.float64)
     orig_y = pd.concat([train_y, test_y]).sort_index().astype(np.float64)
     if preprocess:
-        race = pd.Series(orig_X["race_caucasian"] == 1, dtype=np.float64)
+        race = pd.Series(orig_X["race_caucasian_1"] == 1, dtype=np.float64)
+        sex = pd.Series(orig_X["sex_1"] == 1, dtype=np.float64)
         dropped_X = orig_X.drop(
-            labels=["race_african-american", "race_caucasian"], axis=1
+            labels=[
+                "race_african-american_1",
+                "race_caucasian_1",
+                "race_african-american_0",
+                "race_caucasian_0",
+                "sex_1",
+                "sex_0",
+            ],
+            axis=1,
         )
-        encoded_X = dropped_X.assign(race=race)
+        encoded_X = dropped_X.assign(race=race, sex=sex)
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -103,6 +103,14 @@ class TestAIF360Datasets(unittest.TestCase):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
         self._attempt_dataset(X, y, fairness_info, 6_167, 401, {0, 1}, 0.591)
 
+    def test_dataset_compas_violent_pd_cat(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_compas_violent_df(preprocess=False)
+        self._attempt_dataset(X, y, fairness_info, 4_020, 51, {0, 1}, 0.772)
+
+    def test_dataset_compas_violent_pd_num(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_compas_violent_df(preprocess=True)
+        self._attempt_dataset(X, y, fairness_info, 4_015, 327, {0, 1}, 0.772)
+
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)
         self._attempt_dataset(X, y, fairness_info, 1_000, 20, {"bad", "good"}, 0.748)

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -97,11 +97,11 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_compas_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 5_278, 13, {0, 1}, 0.919)
+        self._attempt_dataset(X, y, fairness_info, 6_172, 51, {0, 1}, 0.954)
 
     def test_dataset_compas_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 5_278, 15, {0, 1}, 0.919)
+        self._attempt_dataset(X, y, fairness_info, 6_167, 401, {0, 1}, 0.954)
 
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -97,11 +97,11 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_compas_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 6_172, 51, {0, 1}, 0.954)
+        self._attempt_dataset(X, y, fairness_info, 6_172, 51, {0, 1}, 0.589)
 
     def test_dataset_compas_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 6_167, 401, {0, 1}, 0.954)
+        self._attempt_dataset(X, y, fairness_info, 6_167, 401, {0, 1}, 0.591)
 
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -101,7 +101,7 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_compas_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 5_278, 12, {0, 1}, 0.919)
+        self._attempt_dataset(X, y, fairness_info, 5_278, 15, {0, 1}, 0.919)
 
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)


### PR DESCRIPTION
This branch began as a quick fix to make sure `fetch_compas_df` respect a user's `preprocess` parameter choice (if provided). However, after poking around other parts of the code, it was determined that the COMPAS dataset compiled by ProPublica should be pulled from GitHub instead of OpenML for better comparability with other papers found in the literature. Moreover, up until now, we did not have code to pull the violent recidivism dataset that ProPublica's GitHub also provides. This has now been implemented as well.

Other major takeaways:

- For both COMPAS datasets, sex, race, and age are protected attributes ("Caucasian", "Female", and ">= 25" are privileged classes, although according to original ProPublica reports, COMPAS originally overpredicted recidivism scores for females; see code comments)
- AIF360 is being leveraged for some data preprocessing (with some unfortunate code duplication (kept to a minimum) in the violent recidivism case; see comments about warnings regarding the removal of 5 rows when preprocessing)
- `urllib.request` is used to download the corresponding CSV files if the user does not have them (in a similar vein to what the MEPS tests do except that this is done by default for a user whenever one of the `fetch` methods is called)
- Updated comments for `fetch_compas_df` to make sure they reflect the new changes (would like some eyes here to make sure I didn't make any mistakes, but I'm pretty sure I got everything).