### PR TITLE
Adding Nursery dataset from OpenML with corresponding tests

### DIFF
--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -520,6 +520,17 @@ experiments_dict["SpeedDating"][
 experiments_dict["SpeedDating"]["task_type"] = "classification"
 experiments_dict["SpeedDating"]["target"] = "match"
 
+experiments_dict["nursery"] = {}
+experiments_dict["nursery"]["dataset_url"] = "https://www.openml.org/d/26"
+experiments_dict["nursery"][
+    "download_arff_url"
+] = "https://www.openml.org/data/download/26/dataset_26_nursery.arff"
+experiments_dict["nursery"][
+    "download_csv_url"
+] = "https://www.openml.org/data/get_csv/26/dataset_26_nursery.arff"
+experiments_dict["nursery"]["task_type"] = "classification"
+experiments_dict["nursery"]["target"] = "class"
+
 experiments_dict["titanic"] = {}
 experiments_dict["titanic"]["dataset_url"] = "https://www.openml.org/d/40945"
 experiments_dict["titanic"][

--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -90,6 +90,7 @@ Other Functions:
 * `fetch_ricci_df`_
 * `fetch_speeddating_df`_
 * `fetch_boston_housing_df`_
+* `fetch_nursery_df`_
 * `fetch_titanic_df`_
 * `fetch_meps_panel19_fy2015_df`_
 * `fetch_meps_panel20_fy2015_df`_
@@ -161,6 +162,7 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_ricci_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_ricci_df
 .. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
 .. _`fetch_boston_housing_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_boston_housing_df
+.. _`fetch_nursery_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_nursery_df
 .. _`fetch_titanic_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_titanic_df
 .. _`fetch_meps_panel19_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel19_fy2015_df
 .. _`fetch_meps_panel20_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel20_fy2015_df
@@ -183,6 +185,7 @@ from .datasets import (
     fetch_meps_panel19_fy2015_df,
     fetch_meps_panel20_fy2015_df,
     fetch_meps_panel21_fy2016_df,
+    fetch_nursery_df,
     fetch_ricci_df,
     fetch_speeddating_df,
     fetch_titanic_df,

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -52,7 +52,7 @@ def fetch_adult_df(preprocess=False):
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
       encode labels in y as 0 or 1 to indicate favorable outcomes;
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -135,7 +135,7 @@ def fetch_bank_df(preprocess=False):
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
       encode labels in y as 0 or 1 to indicate favorable outcomes;
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -335,7 +335,7 @@ def fetch_compas_df(preprocess=False):
       (1 if Female, Caucasian, or at least 25 for the corresponding sex, race, and
       age columns respectively);
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -397,7 +397,7 @@ def fetch_compas_violent_df(preprocess=False):
       (1 if Female, Caucasian, or at least 25 for the corresponding sex, race, and
       age columns respectively);
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -493,7 +493,7 @@ def fetch_creditg_df(preprocess=False):
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
       encode labels in y as 0 or 1 to indicate favorable outcomes;
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -582,7 +582,7 @@ def fetch_ricci_df(preprocess=False):
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
       encode labels in y as 0 or 1 to indicate favorable outcomes;
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -645,7 +645,7 @@ def fetch_speeddating_df(preprocess=False):
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
       encode labels in y as 0 or 1 to indicate favorable outcomes;
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------
@@ -763,6 +763,97 @@ def fetch_boston_housing_df(preprocess=False):
         return orig_X, orig_y, fairness_info
 
 
+def fetch_nursery_df(preprocess=False):
+    """
+    Fetch the `nursery`_ dataset from OpenML and add `fairness_info`.
+
+    It contains data gathered from applicants to public schools in
+    Ljubljana, Slovenia during a competitive time period.
+    Without preprocessing, the dataset has
+    12960 rows and 9 columns.  There are two protected attribute, has_nurs and parents, and the
+    disparate impact is 0.56.  The data has categorical columns (with
+    numeric ones if preprocessing is applied), with no missing values.
+
+    .. _`nursery`: https://www.openml.org/d/26
+
+    Parameters
+    ----------
+    preprocess : boolean, optional, default False
+
+      If True,
+      encode protected attributes in X as 0 or 1 to indicate privileged groups
+      and apply one-hot encoding to any remaining features in X that
+      are categorical and not protected attributes.
+
+    Returns
+    -------
+    result : tuple
+
+      - item 0: pandas Dataframe
+
+          Features X, including both protected and non-protected attributes.
+
+      - item 1: pandas Series
+
+          Labels y.
+
+      - item 3: fairness_info
+
+          JSON meta-data following the format understood by fairness metrics
+          and mitigation operators in `lale.lib.aif360`.
+    """
+    (train_X, train_y), (test_X, test_y) = lale.datasets.openml.fetch(
+        "nursery", "classification", astype="pandas", preprocess=preprocess
+    )
+    orig_X = pd.concat([train_X, test_X]).sort_index()
+    orig_y = pd.concat([train_y, test_y]).sort_index()
+    if preprocess:
+        parents = pd.Series(orig_X["parents_usual"] == 0, dtype=np.float64)
+        has_nurs = pd.Series(orig_X["has_nurs_proper"] == 0, dtype=np.float64)
+        dropped_X = orig_X.drop(
+            labels=[
+                "parents_great_pret",
+                "parents_pretentious",
+                "parents_usual",
+                "has_nurs_proper",
+                "has_nurs_less_proper",
+                "has_nurs_critical",
+                "has_nurs_improper",
+                "has_nurs_very_crit",
+            ],
+            axis=1,
+        )
+        encoded_X = dropped_X.assign(parents=parents, has_nurs=has_nurs)
+        encoded_y = pd.Series(orig_y > 2, dtype=np.float64)
+        fairness_info = {
+            "favorable_labels": [1],
+            "protected_attributes": [
+                {"feature": "parents", "reference_group": [1]},
+            ],
+        }
+        return encoded_X, encoded_y, fairness_info
+    else:
+        fairness_info = {
+            "favorable_labels": ["priority", "spec_prior"],
+            "protected_attributes": [
+                {
+                    "feature": "parents",
+                    "reference_group": ["great_pret", "pretentious"],
+                },
+                {
+                    "feature": "has_nurs",
+                    "reference_group": [
+                        "less_proper",
+                        "improper",
+                        "critical",
+                        "very_crit",
+                    ],
+                },
+            ],
+        }
+        return orig_X, orig_y, fairness_info
+
+
 def fetch_titanic_df(preprocess=False):
     """
     Fetch the `Titanic`_ dataset from OpenML and add `fairness_info`.
@@ -782,7 +873,7 @@ def fetch_titanic_df(preprocess=False):
       If True,
       encode protected attributes in X as 0 or 1 to indicate privileged groups
       and apply one-hot encoding to any remaining features in X that
-      are categorical and not protecteded attributes.
+      are categorical and not protected attributes.
 
     Returns
     -------

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -770,8 +770,8 @@ def fetch_nursery_df(preprocess=False):
     It contains data gathered from applicants to public schools in
     Ljubljana, Slovenia during a competitive time period.
     Without preprocessing, the dataset has
-    12960 rows and 9 columns.  There are two protected attribute, has_nurs and parents, and the
-    disparate impact is 0.56.  The data has categorical columns (with
+    12960 rows and 8 columns.  There is one protected attribute, parents, and the
+    disparate impact is 0.46.  The data has categorical columns (with
     numeric ones if preprocessing is applied), with no missing values.
 
     .. _`nursery`: https://www.openml.org/d/26
@@ -809,46 +809,30 @@ def fetch_nursery_df(preprocess=False):
     orig_y = pd.concat([train_y, test_y]).sort_index()
     if preprocess:
         parents = pd.Series(orig_X["parents_usual"] == 0, dtype=np.float64)
-        has_nurs = pd.Series(orig_X["has_nurs_proper"] == 0, dtype=np.float64)
         dropped_X = orig_X.drop(
             labels=[
                 "parents_great_pret",
                 "parents_pretentious",
                 "parents_usual",
-                "has_nurs_proper",
-                "has_nurs_less_proper",
-                "has_nurs_critical",
-                "has_nurs_improper",
-                "has_nurs_very_crit",
             ],
             axis=1,
         )
-        encoded_X = dropped_X.assign(parents=parents, has_nurs=has_nurs)
-        encoded_y = pd.Series(orig_y > 2, dtype=np.float64)
+        encoded_X = dropped_X.assign(parents=parents)
+        # orig_y == 3 corresponds to "spec_prior"
+        encoded_y = pd.Series((orig_y == 3), dtype=np.float64)
         fairness_info = {
             "favorable_labels": [1],
-            "protected_attributes": [
-                {"feature": "parents", "reference_group": [1]},
-            ],
+            "protected_attributes": [{"feature": "parents", "reference_group": [1]}],
         }
         return encoded_X, encoded_y, fairness_info
     else:
         fairness_info = {
-            "favorable_labels": ["priority", "spec_prior"],
+            "favorable_labels": ["spec_prior"],
             "protected_attributes": [
                 {
                     "feature": "parents",
                     "reference_group": ["great_pret", "pretentious"],
-                },
-                {
-                    "feature": "has_nurs",
-                    "reference_group": [
-                        "less_proper",
-                        "improper",
-                        "critical",
-                        "very_crit",
-                    ],
-                },
+                }
             ],
         }
         return orig_X, orig_y, fairness_info

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -119,6 +119,22 @@ class TestAIF360Datasets(unittest.TestCase):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=True)
         self._attempt_dataset(X, y, fairness_info, 1_000, 58, {0, 1}, 0.748)
 
+    def test_dataset_nursery_pd_cat(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_nursery_df(preprocess=False)
+        self._attempt_dataset(
+            X,
+            y,
+            fairness_info,
+            12_960,
+            8,
+            {"not_recom", "recommend", "very_recom", "priority", "spec_prior"},
+            0.461,
+        )
+
+    def test_dataset_nursery_pd_num(self):
+        X, y, fairness_info = lale.lib.aif360.fetch_nursery_df(preprocess=True)
+        self._attempt_dataset(X, y, fairness_info, 12_960, 25, {0, 1}, 0.461)
+
     def test_dataset_ricci_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_ricci_df(preprocess=False)
         self._attempt_dataset(


### PR DESCRIPTION
Title should be pretty self-explanatory. More information about the dataset (https://www.openml.org/d/26) can be found here: https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.142.2022&rep=rep1&type=pdf

One paper (https://arxiv.org/pdf/2006.04292.pdf; corresponding code: https://github.com/yromano/fair_dummies/tree/master/data) uses this dataset to assert that trained models do not exploit the `finance` attribute when attempting to learn in a fair manner, but when I was determining what made sense for default `fairness_info` and preprocessing, I was not able to easily find features that resulted in unfair disparate impact when treating the problem as a binary classification one between "recommended" (in any capacity) and "not recommended". (e.g. `finance` actually is perfectly split between the two classes in terms of outcomes, while one value for `health` results in all "not recommended" examples). I ended up going with a protected attribute and privileged classes of `parent=["great_pret", "pretentious"]` with a favorable label of `spec_prior`. Open to updating in the future if we find a better combination.