### PR TITLE
Trying to fix documentation build problems

### DIFF
--- a/docs/README-cn.md
+++ b/docs/README-cn.md
@@ -13,7 +13,7 @@ Lale是一个半自动化数据科学的Python库. 通过Lale，您可以简单�
 * [scikit-learn用户入门指南](https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/docs_guide_for_sklearn_users.ipynb) 
 * [安装说明](https://github.com/IBM/lale/blob/master/docs/installation.rst)
 * 技术概述[幻灯片](https://github.com/IBM/lale/blob/master/talks/2019-1105-lale.pdf), [笔记本](https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/talk_2019-1105-lale.ipynb), and [视频](https://www.youtube.com/watch?v=R51ZDJ64X18&list=PLGVZCDnMOq0pwoOqsaA87cAoNM4MWr51M&index=35&t=0s)
-* IBM的[AutoAI SDK](http://wml-api-pyclient-v4.mybluemix.net/#autoai-beta-ibm-cloud-only)使用Lale, 请参阅演示[笔记本](https://dataplatform.cloud.ibm.com/exchange/public/entry/view/a2d87b957b60c846267137bfae130dca)
+* IBM的[AutoAI SDK](http://wml-api-pyclient-v4.mybluemix.net/#autoai-beta-ibm-cloud-only)使用Lale, [请参阅演示 笔记本](https://dataplatform.cloud.ibm.com/exchange/public/entry/view/a2d87b957b60c846267137bfae130dca)
 * 包装指南[新运算符](https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/docs_new_operators.ipynb)
 * [贡献]指南(https://github.com/IBM/lale/blob/master/CONTRIBUTING.md)
 * [常问问题](https://github.com/IBM/lale/blob/master/docs/faq.rst)

--- a/docs/README-fr.md
+++ b/docs/README-fr.md
@@ -21,7 +21,7 @@ Lale peut être installé comme n'importe quelle autre bibliothèque python et p
 * [Introduction](https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/docs_guide_for_sklearn_users.ipynb) pour les utilisateurs de scikit-learn
 * Instructions pour l'[installation](https://github.com/IBM/lale/blob/master/docs/installation.rst)
 * Aperçu technique [slides](https://github.com/IBM/lale/blob/master/talks/2019-1105-lale.pdf), [notebook](https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/talk_2019-1105-lale.ipynb), et [video](https://www.youtube.com/watch?v=R51ZDJ64X18&list=PLGVZCDnMOq0pwoOqsaA87cAoNM4MWr51M&index=35&t=0s)
-* IBM [AutoAI SDK](http://wml-api-pyclient-v4.mybluemix.net/#autoai-beta-ibm-cloud-only) utilise Lale, voir le [notebook](https://dataplatform.cloud.ibm.com/exchange/public/entry/view/a2d87b957b60c846267137bfae130dca)
+* IBM [AutoAI SDK](http://wml-api-pyclient-v4.mybluemix.net/#autoai-beta-ibm-cloud-only) utilise Lale, voir le [demo notebook](https://dataplatform.cloud.ibm.com/exchange/public/entry/view/a2d87b957b60c846267137bfae130dca)
 * Guide pour ajouter de [nouveaux operateurs](https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/docs_new_operators.ipynb)
 * Guide pour [contribuer](https://github.com/IBM/lale/blob/master/CONTRIBUTING.md) au projet Lale
 * [FAQ](https://github.com/IBM/lale/blob/master/docs/faq.rst)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ apidoc_separate_modules = True
 autoclass_content = "both"
 
 # Mock requirements to save resources during doc build machine setup
-autodoc_mock_imports = ["torch"]
+autodoc_mock_imports = ["aif360", "pytorch", "tensorflow", "torch"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -25,4 +25,4 @@ m2r
 sphinx_rtd_theme
 sphinxcontrib.apidoc
 PyYAML
-tensorflow>=1.13.1,<2
+

--- a/lale/helpers.py
+++ b/lale/helpers.py
@@ -312,14 +312,21 @@ def cross_val_score(estimator, X, y=None, scoring=accuracy_score, cv=5):
     """
     Use the given estimator to perform fit and predict for splits defined by 'cv' and compute the given score on
     each of the splits.
-    :param estimator: A valid sklearn_wrapper estimator
-    :param X, y: Valid data and target values that work with the estimator
-    :param scoring: a scorer object from sklearn.metrics (https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics)
-             Default value is accuracy_score.
-    :param cv: an integer or an object that has a split function as a generator yielding (train, test) splits as arrays of indices.
+
+    Parameters
+    ----------
+
+    estimator: A valid sklearn_wrapper estimator
+    X, y: Valid data and target values that work with the estimator
+    scoring: a scorer object from sklearn.metrics (https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics)
+        Default value is accuracy_score.
+    cv: an integer or an object that has a split function as a generator yielding (train, test) splits as arrays of indices.
         Integer value is used as number of folds in sklearn.model_selection.StratifiedKFold, default is 5.
         Note that any of the iterators from https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators can be used here.
-    :return: cv_results: a list of scores corresponding to each cross validation fold
+
+    Returns
+    -------
+    cv_results: a list of scores corresponding to each cross validation fold
     """
     if isinstance(cv, int):
         cv = StratifiedKFold(cv)

--- a/lale/lib/autogen/huber_regressor.py
+++ b/lale/lib/autogen/huber_regressor.py
@@ -85,7 +85,7 @@ _hyperparams_schema = {
                     "maximumForOptimizer": 0.01,
                     "distribution": "loguniform",
                     "default": 1e-05,
-                    "description": "The iteration will stop when ``max{|proj g_i | i = 1, ",
+                    "description": "The iteration will stop when ``max{|proj g_i | i = 1, ..., n}`` <= ``tol`` where pg_i is the i-th component of the projected gradient.",
                 },
             },
         }

--- a/lale/lib/imblearn/adasyn.py
+++ b/lale/lib/imblearn/adasyn.py
@@ -89,6 +89,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -112,7 +113,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted
 class.""",
                             "type": "object",

--- a/lale/lib/imblearn/borderline_smote.py
+++ b/lale/lib/imblearn/borderline_smote.py
@@ -86,6 +86,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -109,7 +110,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted
 class.""",
                             "type": "object",

--- a/lale/lib/imblearn/instance_hardness_threshold.py
+++ b/lale/lib/imblearn/instance_hardness_threshold.py
@@ -108,6 +108,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -131,7 +132,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted class.""",
                             "type": "object",
                         },

--- a/lale/lib/imblearn/random_over_sampler.py
+++ b/lale/lib/imblearn/random_over_sampler.py
@@ -74,6 +74,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -97,7 +98,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted
 class.""",
                             "type": "object",

--- a/lale/lib/imblearn/smote.py
+++ b/lale/lib/imblearn/smote.py
@@ -83,6 +83,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -106,7 +107,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted
 class.""",
                             "type": "object",

--- a/lale/lib/imblearn/smoteenn.py
+++ b/lale/lib/imblearn/smoteenn.py
@@ -82,6 +82,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -105,7 +106,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted
 class.""",
                             "type": "object",

--- a/lale/lib/imblearn/svm_smote.py
+++ b/lale/lib/imblearn/svm_smote.py
@@ -89,6 +89,7 @@ majority class after resampling. Therefore, the ratio is expressed as
 :math:`\\alpha_{os} = N_{rm} / N_{M}` where :math:`N_{rm}` is the
 number of samples in the minority class after resampling and
 :math:`N_{M}` is the number of samples in the majority class.
+
 .. warning::
     ``float`` is only available for **binary** classification. An
     error is raised for multi-class classification.""",
@@ -112,7 +113,7 @@ Possible choices are:
                             ],
                         },
                         {
-                            "description": """- When ``dict``, the keys correspond to the targeted classes.
+                            "description": """When ``dict``, the keys correspond to the targeted classes.
 The values correspond to the desired number of samples for each targeted
 class.""",
                             "type": "object",

--- a/lale/lib/lale/halving_grid_search_cv.py
+++ b/lale/lib/lale/halving_grid_search_cv.py
@@ -241,7 +241,7 @@ _hyperparams_schema = {
                     "default": None,
                 },
                 "factor": {
-                    "description": """The `halving’ parameter, which determines the proportion of candidates
+                    "description": """The `halving` parameter, which determines the proportion of candidates
 that are selected for each subsequent iteration. For example, factor=3 means that only one third of the candidates are selected.""",
                     "type": "number",
                     "minimum": 1,

--- a/lale/lib/lightgbm/lgbm_classifier.py
+++ b/lale/lib/lightgbm/lgbm_classifier.py
@@ -269,7 +269,7 @@ _hyperparams_schema = {
                 "importance_type": {
                     "enum": ["split", "gain"],
                     "default": "split",
-                    "description": "The type of feature importance to be filled into feature_importances_.",
+                    "description": "The type of feature importance to be filled into `feature_importances_`.",
                 },
             },
         },

--- a/lale/lib/lightgbm/lgbm_regressor.py
+++ b/lale/lib/lightgbm/lgbm_regressor.py
@@ -252,7 +252,7 @@ _hyperparams_schema = {
                 "importance_type": {
                     "enum": ["split", "gain"],
                     "default": "split",
-                    "description": "The type of feature importance to be filled into feature_importances_.",
+                    "description": "The type of feature importance to be filled into `feature_importances_`.",
                 },
             },
         }

--- a/lale/lib/sklearn/multinomial_nb.py
+++ b/lale/lib/sklearn/multinomial_nb.py
@@ -101,7 +101,7 @@ _input_predict_proba_schema = {
     },
 }
 _output_predict_proba_schema = {
-    "description": "Returns the probability of the samples for each class in the model. The columns correspond to the classes in sorted order, as they appear in the attribute classes_.",
+    "description": "Returns the probability of the samples for each class in the model. The columns correspond to the classes in sorted order, as they appear in the attribute `classes_`.",
     "type": "array",
     "items": {"type": "array", "items": {"type": "number"}},
 }

--- a/lale/lib/sklearn/rfe.py
+++ b/lale/lib/sklearn/rfe.py
@@ -28,7 +28,7 @@ _hyperparams_schema = {
             "additionalProperties": False,
             "properties": {
                 "estimator": {
-                    "description": "A supervised learning estimator with a fit method that provides information about feature importance either through a coef_ attribute or through a feature_importances_ attribute.",
+                    "description": "A supervised learning estimator with a fit method that provides information about feature importance either through a `coef_` attribute or through a `feature_importances_` attribute.",
                     "laleType": "operator",
                 },
                 "n_features_to_select": {
@@ -164,7 +164,7 @@ if sklearn.__version__ >= "0.24":
         importance_getter={
             "anyOf": [
                 {
-                    "description": "Use the feature importance either through a coef_ or feature_importances_ attributes of estimator.",
+                    "description": "Use the feature importance either through a `coef_` or `feature_importances_` attributes of estimator.",
                     "enum": ["auto"],
                 },
                 {

--- a/lale/lib/xgboost/xgb_regressor.py
+++ b/lale/lib/xgboost/xgb_regressor.py
@@ -301,7 +301,7 @@ Refer to https://xgboost.readthedocs.io/en/latest/parameter.html. """,
                 "importance_type": {
                     "enum": ["gain", "weight", "cover", "total_gain", "total_cover"],
                     "default": "gain",
-                    "description": "The feature importance type for the feature_importances_ property.",
+                    "description": "The feature importance type for the `feature_importances_` property.",
                 },
                 "seed": {
                     "default": None,

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -1209,9 +1209,9 @@ class IndividualOp(Operator):
         """This is the hyperparameters that are currently set.
         Some of them may not have been set explicitly
         (e.g. if this is a clone of an operator,
-         some of these may be defaults.
-         To get the hyperparameters that were actually set,
-         use :meth:`hyperparams`
+        some of these may be defaults.
+        To get the hyperparameters that were actually set,
+        use :meth:`hyperparams`
         """
         return getattr(self, "_hyperparams", None)
 
@@ -2171,6 +2171,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `freeze_trained`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("freeze_trained"), DeprecationWarning)
         try:
@@ -2198,6 +2199,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `get_pipeline`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("get_pipeline"), DeprecationWarning)
         try:
@@ -2213,6 +2215,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `summary`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("summary"), DeprecationWarning)
         try:
@@ -2228,6 +2231,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `transform`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("transform"), DeprecationWarning)
         try:
@@ -2243,6 +2247,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `predict`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("predict"), DeprecationWarning)
         try:
@@ -2258,6 +2263,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `predict_proba`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("predict_proba"), DeprecationWarning)
         try:
@@ -2273,6 +2279,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `decision_function`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("decision_function"), DeprecationWarning)
         try:
@@ -2288,6 +2295,7 @@ class TrainableIndividualOp(PlannedIndividualOp, TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `score`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("score"), DeprecationWarning)
         try:
@@ -3475,6 +3483,7 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `transform`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("transform"), DeprecationWarning)
         try:
@@ -3489,6 +3498,7 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `predict`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("predict"), DeprecationWarning)
         try:
@@ -3503,6 +3513,7 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `predict_proba`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("predict_proba"), DeprecationWarning)
         try:
@@ -3517,6 +3528,7 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `decision_function`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("decision_function"), DeprecationWarning)
         try:
@@ -3531,6 +3543,7 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
            operator, because the learned coefficients could be
            accidentally overwritten by retraining. Call `score`
            on the trained operator returned by `fit` instead.
+
         """
         warnings.warn(_mutation_warning("score"), DeprecationWarning)
         try:

--- a/lale/search/lale_smac.py
+++ b/lale/search/lale_smac.py
@@ -74,7 +74,8 @@ def get_smac_space(
     lale_pgo: Optional[PGO] = None,
     data_schema: Dict[str, Any] = {},
 ) -> ConfigurationSpace:
-    """Top level function: given a lale operator, returns a ConfigurationSpace for use with SMAC
+    """Top level function: given a lale operator, returns a ConfigurationSpace for use with SMAC.
+
     Parameters
     ----------
     op : The lale PlannedOperator

--- a/lale/search/search_space_grid.py
+++ b/lale/search/search_space_grid.py
@@ -67,6 +67,7 @@ def get_search_space_grids(
     data_schema: Dict[str, Any] = {},
 ) -> List[SearchSpaceGrid]:
     """Top level function: given a lale operator, returns a list of hp grids.
+
     Parameters
     ----------
     op : The lale PlannedOperator

--- a/lale/settings.py
+++ b/lale/settings.py
@@ -7,11 +7,11 @@ def set_disable_data_schema_validation(flag: bool):
     against the data schemas defined for an operator. This method allows users to control
     whether the data schema validation should be turned on or not.
 
-        Parameters
-        ----------
-        flag : bool
-            A value of True will disable the data schema validation, and a value of False will enable it.
-            It is True by default.
+    Parameters
+    ----------
+    flag : bool
+        A value of True will disable the data schema validation, and a value of False will enable it.
+        It is True by default.
     """
     global disable_data_schema_validation
     disable_data_schema_validation = flag
@@ -22,11 +22,11 @@ def set_disable_hyperparams_schema_validation(flag: bool):
     the json schema defined for hyperparameters of an operator. This method allows users to control
     whether such validation should be turned on or not.
 
-        Parameters
-        ----------
-        flag : bool
-            A value of True will disable the hyperparameter schema validation, and a value of False will enable it.
-            It is False by default.
+    Parameters
+    ----------
+    flag : bool
+        A value of True will disable the hyperparameter schema validation, and a value of False will enable it.
+        It is False by default.
     """
     global disable_hyperparams_schema_validation
     disable_hyperparams_schema_validation = flag


### PR DESCRIPTION
The documentation builds on readthedocs have been timing out and/or running out of memory. One of the big dependencies is tensorflow, so this PR removes that from docs/requirements.txt and adds it to autodoc_mock_imports in docs/conf.py instead. Locally, that seems to speed up the docs build from around 10 minutes to around 4 minutes. While doing these experiments, I also noticed that there is an excessive number of warnings during the docs build. This PR resolves many of the easy ones (e.g., caused by RST indentation issues).