### PR TITLE
Improvements to documentation and schemas.

### DIFF
--- a/docs/papers.rst
+++ b/docs/papers.rst
@@ -1,6 +1,38 @@
 Papers
 ======
 
+"Engineering Fair Machine Learning Pipelines".
+Martin Hirzel, Kiran Kate, and Parikshit Ram.
+ICLR Workshop on Responsible AI (RAI@ICLR), May 2021. 
+http://hirzels.com/martin/papers/rai21-fairness.pdf
+
+.. code:: BibTeX
+
+    @InProceedings{hirzel_kate_ram_2021,
+      title = "Engineering Fair Machine Learning Pipelines",
+      author = "Hirzel, Martin and Kate, Kiran and Ram, Parikshit",
+      booktitle = "ICLR Workshop on Responsible AI (RAI@ICLR)",
+      year = 2021,
+      month = may,
+      url = "http://hirzels.com/martin/papers/rai21-fairness.pdf" }
+
+"Extracting Hyperparameter Constraints from Code".
+Ingkarat Rak-amnouykit, Ana Milanova, Guillaume Baudart,
+Martin Hirzel, and Julian Dolby.
+ICLR Workshop on Security and Safety in Machine Learning Systems (SecML@ICLR),
+May 2021. 
+https://aisecure-workshop.github.io/aml-iclr2021/papers/18.pdf
+
+.. code:: BibTeX
+
+    @InProceedings{rakamnouykit_et_al_2021-secml,
+      title = "Extracting Hyperparameter Constraints from Code",
+      author = "Rak-amnouykit, Ingkarat and Milanova, Ana and Baudart, Guillaume and Hirzel, Martin and Dolby, Julian",
+      booktitle = "ICLR Workshop on Security and Safety in Machine Learning Systems (SecML@ICLR)",
+      year = 2021,
+      month = may,
+      url = "https://aisecure-workshop.github.io/aml-iclr2021/papers/18.pdf" }
+
 "Lale: Consistent Automated Machine Learning".
 Guillaume Baudart, Martin Hirzel, Kiran Kate, Parikshit Ram, and
 Avraham Shinnar.

--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -72,6 +72,23 @@ Metrics:
 * `statistical_parity_difference`_
 * `theil_index`_
 
+Datasets:
+================
+* `fetch_adult_df`_
+* `fetch_bank_df`_
+* `fetch_boston_housing_df`_
+* `fetch_compas_df`_
+* `fetch_compas_violent_df`_
+* `fetch_creditg_df`_
+* `fetch_meps_panel19_fy2015_df`_
+* `fetch_meps_panel20_fy2015_df`_
+* `fetch_meps_panel21_fy2016_df`_
+* `fetch_nursery_df`_
+* `fetch_ricci_df`_
+* `fetch_speeddating_df`_
+* `fetch_tae_df`_
+* `fetch_titanic_df`_
+
 Other Classes and Operators:
 ============================
 * `FairStratifiedKFold`_
@@ -82,21 +99,6 @@ Other Functions:
 ================
 * `dataset_to_pandas`_
 * `fair_stratified_train_test_split`_
-* `fetch_adult_df`_
-* `fetch_bank_df`_
-* `fetch_compas_df`_
-* `fetch_compas_violent_df`_
-* `fetch_creditg_df`_
-* `fetch_ricci_df`_
-* `fetch_speeddating_df`_
-* `fetch_boston_housing_df`_
-* `fetch_nursery_df`_
-* `fetch_titanic_df`_
-* `fetch_meps_panel19_fy2015_df`_
-* `fetch_meps_panel20_fy2015_df`_
-* `fetch_meps_panel21_fy2016_df`_
-* `fetch_tae_df`_
-
 
 Mitigator Patterns:
 ===================

--- a/lale/lib/sklearn/_common_schemas.py
+++ b/lale/lib/sklearn/_common_schemas.py
@@ -38,6 +38,14 @@ schema_X_numbers = {
     },
 }
 
+schema_1D_cats = {
+    "anyOf": [
+        {"type": "array", "items": {"type": "string"}},
+        {"type": "array", "items": {"type": "number"}},
+        {"type": "array", "items": {"type": "boolean"}},
+    ],
+}
+
 schema_2D_numbers = {
     "type": "array",
     "items": {"type": "array", "items": {"type": "number"}},

--- a/lale/lib/sklearn/dummy_classifier.py
+++ b/lale/lib/sklearn/dummy_classifier.py
@@ -19,6 +19,8 @@ import sklearn.dummy
 import lale.docstrings
 import lale.operators
 
+from ._common_schemas import schema_1D_cats, schema_2D_numbers
+
 _hyperparams_schema = {
     "allOf": [
         {
@@ -67,8 +69,8 @@ _hyperparams_schema = {
                     "anyOf": [
                         {"type": ["integer", "string"]},
                         {"enum": [None]},
-                        {"default": None},
                     ],
+                    "default": None,
                 },
             },
         },
@@ -82,13 +84,14 @@ _input_fit_schema = {
         "X": {
             "description": "Features; the outer array is over samples.",
             "type": "array",
-            "items": {"type": "array"},
+            "items": {"type": "array", "items": {"laleType": "Any"}},
         },
         "y": {
             "description": "Target class labels.",
             "anyOf": [
-                {"type": "array", "items": {"type": "number"}},
                 {"type": "array", "items": {"type": "string"}},
+                {"type": "array", "items": {"type": "number"}},
+                {"type": "array", "items": {"type": "boolean"}},
             ],
         },
     },
@@ -96,6 +99,7 @@ _input_fit_schema = {
 
 _input_predict_schema = {
     "type": "object",
+    "additionalProperties": False,
     "properties": {
         "X": {
             "description": "Features; the outer array is over samples.",
@@ -105,12 +109,17 @@ _input_predict_schema = {
     },
 }
 
-_output_predict_schema = {
-    "description": "Predicted class label per sample.",
-    "anyOf": [
-        {"type": "array", "items": {"type": "number"}},
-        {"type": "array", "items": {"type": "string"}},
-    ],
+_input_predict_proba_schema = {
+    "type": "object",
+    "required": ["X"],
+    "additionalProperties": False,
+    "properties": {
+        "X": {
+            "description": "Features; the outer array is over samples.",
+            "type": "array",
+            "items": {"type": "array", "items": {"laleType": "Any"}},
+        }
+    },
 }
 
 _combined_schemas = {
@@ -126,10 +135,11 @@ _combined_schemas = {
         "hyperparams": _hyperparams_schema,
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
-        "output_predict": _output_predict_schema,
+        "output_predict": schema_1D_cats,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": schema_2D_numbers,
     },
 }
-
 
 DummyClassifier = lale.operators.make_operator(
     sklearn.dummy.DummyClassifier, _combined_schemas

--- a/lale/lib/sklearn/extra_trees_classifier.py
+++ b/lale/lib/sklearn/extra_trees_classifier.py
@@ -207,7 +207,12 @@ _hyperparams_schema = {
                     "default": None,
                 },
             },
-        }
+        },
+        {
+            "description": "This classifier does not support sparse labels.",
+            "type": "object",
+            "laleNot": "y/isSparse",
+        },
     ],
 }
 

--- a/lale/lib/sklearn/random_forest_classifier.py
+++ b/lale/lib/sklearn/random_forest_classifier.py
@@ -235,7 +235,12 @@ _hyperparams_schema = {
                     "default": None,
                 },
             },
-        }
+        },
+        {
+            "description": "This classifier does not support sparse labels.",
+            "type": "object",
+            "laleNot": "y/isSparse",
+        },
     ],
 }
 


### PR DESCRIPTION
- updated papers.rst to mention the workshop papers at ICLR
- in the package documentation for lale.lib.aif360, moved datasets to their own header
- in ExtraTreesClassifier and RandomForestClassifier, added constraint against sparse labels
- in DummyClassifier, added missing schemas for predict_proba, and changed schemas for labels to allow boolean
