### PR TITLE
Contributing Stacking ensembles and making changes to Voting and Bagging ensembles

### DIFF
--- a/lale/lib/autogen/calibrated_classifier_cv.py
+++ b/lale/lib/autogen/calibrated_classifier_cv.py
@@ -47,13 +47,25 @@ _hyperparams_schema = {
                     "default": "sigmoid",
                 },
                 "cv": {
-                    "XXX TODO XXX": 'integer, cross-validation generator, iterable or "prefit", optional',
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
                 },
             },
         }

--- a/lale/lib/autogen/elastic_net_cv.py
+++ b/lale/lib/autogen/elastic_net_cv.py
@@ -143,11 +143,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "copy_X": {
                     "type": "boolean",

--- a/lale/lib/autogen/elastic_net_cv.py
+++ b/lale/lib/autogen/elastic_net_cv.py
@@ -134,13 +134,20 @@ _hyperparams_schema = {
                     "description": "The tolerance for the optimization: if the updates are smaller than ``tol``, the optimization code checks the dual gap for optimality and continues until it is smaller than ``tol``.",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "copy_X": {
                     "type": "boolean",

--- a/lale/lib/autogen/lars_cv.py
+++ b/lale/lib/autogen/lars_cv.py
@@ -97,11 +97,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "max_n_alphas": {
                     "type": "integer",

--- a/lale/lib/autogen/lars_cv.py
+++ b/lale/lib/autogen/lars_cv.py
@@ -88,13 +88,20 @@ _hyperparams_schema = {
                     "description": "Whether to use a precomputed Gram matrix to speed up calculations",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "max_n_alphas": {
                     "type": "integer",

--- a/lale/lib/autogen/lasso_cv.py
+++ b/lale/lib/autogen/lasso_cv.py
@@ -132,13 +132,20 @@ _hyperparams_schema = {
                     "description": "If ``True``, X will be copied; else, it may be overwritten.",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "verbose": {
                     "anyOf": [{"type": "boolean"}, {"type": "integer"}],

--- a/lale/lib/autogen/lasso_cv.py
+++ b/lale/lib/autogen/lasso_cv.py
@@ -141,11 +141,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "verbose": {
                     "anyOf": [{"type": "boolean"}, {"type": "integer"}],

--- a/lale/lib/autogen/lasso_lars_cv.py
+++ b/lale/lib/autogen/lasso_lars_cv.py
@@ -82,13 +82,20 @@ _hyperparams_schema = {
                     "description": "Whether to use a precomputed Gram matrix to speed up calculations",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "max_n_alphas": {
                     "type": "integer",

--- a/lale/lib/autogen/lasso_lars_cv.py
+++ b/lale/lib/autogen/lasso_lars_cv.py
@@ -91,11 +91,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "max_n_alphas": {
                     "type": "integer",

--- a/lale/lib/autogen/logistic_regression_cv.py
+++ b/lale/lib/autogen/logistic_regression_cv.py
@@ -80,13 +80,25 @@ _hyperparams_schema = {
                     "description": "Specifies if a constant (a.k.a",
                 },
                 "cv": {
-                    "XXX TODO XXX": "integer or cross-validation generator, default: None",
-                    "description": "The default cross-validation generator used is Stratified K-Folds",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
                 },
                 "dual": {
                     "type": "boolean",

--- a/lale/lib/autogen/multi_task_elastic_net_cv.py
+++ b/lale/lib/autogen/multi_task_elastic_net_cv.py
@@ -116,13 +116,20 @@ _hyperparams_schema = {
                     "description": "The tolerance for the optimization: if the updates are smaller than ``tol``, the optimization code checks the dual gap for optimality and continues until it is smaller than ``tol``.",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "copy_X": {
                     "type": "boolean",

--- a/lale/lib/autogen/multi_task_elastic_net_cv.py
+++ b/lale/lib/autogen/multi_task_elastic_net_cv.py
@@ -125,11 +125,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "copy_X": {
                     "type": "boolean",

--- a/lale/lib/autogen/multi_task_lasso_cv.py
+++ b/lale/lib/autogen/multi_task_lasso_cv.py
@@ -114,13 +114,20 @@ _hyperparams_schema = {
                     "description": "If ``True``, X will be copied; else, it may be overwritten.",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "verbose": {
                     "anyOf": [{"type": "boolean"}, {"type": "integer"}],

--- a/lale/lib/autogen/multi_task_lasso_cv.py
+++ b/lale/lib/autogen/multi_task_lasso_cv.py
@@ -123,11 +123,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "verbose": {
                     "anyOf": [{"type": "boolean"}, {"type": "integer"}],

--- a/lale/lib/autogen/orthogonal_matching_pursuit_cv.py
+++ b/lale/lib/autogen/orthogonal_matching_pursuit_cv.py
@@ -83,11 +83,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "n_jobs": {
                     "anyOf": [{"type": "integer"}, {"enum": [None]}],

--- a/lale/lib/autogen/orthogonal_matching_pursuit_cv.py
+++ b/lale/lib/autogen/orthogonal_matching_pursuit_cv.py
@@ -74,13 +74,20 @@ _hyperparams_schema = {
                     "description": "Maximum numbers of iterations to perform, therefore maximum features to include",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
-                    "type": "integer",
-                    "minimumForOptimizer": 3,
-                    "maximumForOptimizer": 4,
-                    "distribution": "uniform",
-                    "default": 3,
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
+                    ],
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "n_jobs": {
                     "anyOf": [{"type": "integer"}, {"enum": [None]}],

--- a/lale/lib/autogen/ridge_classifier_cv.py
+++ b/lale/lib/autogen/ridge_classifier_cv.py
@@ -67,18 +67,20 @@ _hyperparams_schema = {
                     "description": "A string (see model evaluation documentation) or a scorer callable object / function with signature ``scorer(estimator, X, y)``.",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {
-                            "type": "integer",
-                            "minimumForOptimizer": 3,
-                            "maximumForOptimizer": 4,
-                            "distribution": "uniform",
-                        },
-                        {"enum": [None]},
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "default": None,
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "class_weight": {
                     "XXX TODO XXX": "dict or 'balanced', optional",

--- a/lale/lib/autogen/ridge_classifier_cv.py
+++ b/lale/lib/autogen/ridge_classifier_cv.py
@@ -76,11 +76,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "class_weight": {
                     "XXX TODO XXX": "dict or 'balanced', optional",

--- a/lale/lib/autogen/ridge_cv.py
+++ b/lale/lib/autogen/ridge_cv.py
@@ -80,11 +80,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "gcv_mode": {
                     "enum": [None, "auto", "svd", "eigen"],

--- a/lale/lib/autogen/ridge_cv.py
+++ b/lale/lib/autogen/ridge_cv.py
@@ -71,18 +71,20 @@ _hyperparams_schema = {
                     "description": "A string (see model evaluation documentation) or a scorer callable object / function with signature ``scorer(estimator, X, y)``.",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {
-                            "type": "integer",
-                            "minimumForOptimizer": 3,
-                            "maximumForOptimizer": 4,
-                            "distribution": "uniform",
-                        },
-                        {"enum": [None]},
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "default": None,
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "gcv_mode": {
                     "enum": [None, "auto", "svd", "eigen"],

--- a/lale/lib/sklearn/__init__.py
+++ b/lale/lib/sklearn/__init__.py
@@ -153,6 +153,7 @@ Clustering:
 from .ada_boost_classifier import AdaBoostClassifier
 from .ada_boost_regressor import AdaBoostRegressor
 from .bagging_classifier import BaggingClassifier
+from .bagging_regressor import BaggingRegressor
 from .column_transformer import ColumnTransformer
 from .decision_tree_classifier import DecisionTreeClassifier
 from .decision_tree_regressor import DecisionTreeRegressor

--- a/lale/lib/sklearn/__init__.py
+++ b/lale/lib/sklearn/__init__.py
@@ -150,6 +150,8 @@ Clustering:
 .. _`StackingRegressor`: lale.lib.sklearn.stacking_regressor.html
 """
 
+from sklearn import __version__ as sklearn_version
+
 from .ada_boost_classifier import AdaBoostClassifier
 from .ada_boost_regressor import AdaBoostRegressor
 from .bagging_classifier import BaggingClassifier
@@ -200,12 +202,15 @@ from .select_k_best import SelectKBest
 from .sgd_classifier import SGDClassifier
 from .sgd_regressor import SGDRegressor
 from .simple_imputer import SimpleImputer
-from .stacking_classifier import StackingClassifier
-from .stacking_regressor import StackingRegressor
+
+if sklearn_version >= "0.21":
+    from .stacking_classifier import StackingClassifier
+    from .stacking_regressor import StackingRegressor
+    from .voting_regressor import VotingRegressor
+
 from .standard_scaler import StandardScaler
 from .svc import SVC
 from .svr import SVR
 from .tfidf_vectorizer import TfidfVectorizer
 from .variance_threshold import VarianceThreshold
 from .voting_classifier import VotingClassifier
-from .voting_regressor import VotingRegressor

--- a/lale/lib/sklearn/__init__.py
+++ b/lale/lib/sklearn/__init__.py
@@ -38,9 +38,9 @@ Classifiers:
 * lale.lib.sklearn. `RandomForestClassifier`_
 * lale.lib.sklearn. `RidgeClassifier`_
 * lale.lib.sklearn. `SGDClassifier`_
+* lale.lib.sklearn. `StackingClassifier`_
 * lale.lib.sklearn. `SVC`_
 * lale.lib.sklearn. `VotingClassifier`_
-* lale.lib.sklearn. `StackingClassifier`_
 
 Regressors:
 
@@ -51,12 +51,13 @@ Regressors:
 * lale.lib.sklearn. `GradientBoostingRegressor`_
 * lale.lib.sklearn. `KNeighborsRegressor`_
 * lale.lib.sklearn. `LinearRegression`_
+* lale.lib.sklearn. `LinearSVR`_
 * lale.lib.sklearn. `RandomForestRegressor`_
 * lale.lib.sklearn. `Ridge`_
 * lale.lib.sklearn. `SGDRegressor`_
-* lale.lib.sklearn. `SVR`_
-* lale.lib.sklearn. `LinearSVR`_
 * lale.lib.sklearn. `StackingRegressor`_
+* lale.lib.sklearn. `SVR`_
+* lale.lib.sklearn. `VotingRegressor`_
 
 Transformers:
 
@@ -135,6 +136,7 @@ Transformers:
 .. _`TfidfVectorizer`: lale.lib.sklearn.tfidf_vectorizer.html
 .. _`VarianceThreshold`: lale.lib.sklearn.variance_threshold.html
 .. _`VotingClassifier`: lale.lib.sklearn.voting_classifier.html
+.. _`VotingRegressor`: lale.lib.sklearn.voting_regressor.html
 .. _`StackingClassifier`: lale.lib.sklearn.stacking_classifier.html
 .. _`StackingRegressor`: lale.lib.sklearn.stacking_regressor.html
 """
@@ -193,3 +195,4 @@ from .svr import SVR
 from .tfidf_vectorizer import TfidfVectorizer
 from .variance_threshold import VarianceThreshold
 from .voting_classifier import VotingClassifier
+from .voting_regressor import VotingRegressor

--- a/lale/lib/sklearn/__init__.py
+++ b/lale/lib/sklearn/__init__.py
@@ -40,6 +40,7 @@ Classifiers:
 * lale.lib.sklearn. `SGDClassifier`_
 * lale.lib.sklearn. `SVC`_
 * lale.lib.sklearn. `VotingClassifier`_
+* lale.lib.sklearn. `StackingClassifier`_
 
 Regressors:
 
@@ -55,6 +56,7 @@ Regressors:
 * lale.lib.sklearn. `SGDRegressor`_
 * lale.lib.sklearn. `SVR`_
 * lale.lib.sklearn. `LinearSVR`_
+* lale.lib.sklearn. `StackingRegressor`_
 
 Transformers:
 
@@ -133,6 +135,8 @@ Transformers:
 .. _`TfidfVectorizer`: lale.lib.sklearn.tfidf_vectorizer.html
 .. _`VarianceThreshold`: lale.lib.sklearn.variance_threshold.html
 .. _`VotingClassifier`: lale.lib.sklearn.voting_classifier.html
+.. _`StackingClassifier`: lale.lib.sklearn.stacking_classifier.html
+.. _`StackingRegressor`: lale.lib.sklearn.stacking_regressor.html
 """
 
 from .ada_boost_classifier import AdaBoostClassifier
@@ -181,6 +185,8 @@ from .select_k_best import SelectKBest
 from .sgd_classifier import SGDClassifier
 from .sgd_regressor import SGDRegressor
 from .simple_imputer import SimpleImputer
+from .stacking_classifier import StackingClassifier
+from .stacking_regressor import StackingRegressor
 from .standard_scaler import StandardScaler
 from .svc import SVC
 from .svr import SVR

--- a/lale/lib/sklearn/ada_boost_classifier.py
+++ b/lale/lib/sklearn/ada_boost_classifier.py
@@ -18,29 +18,15 @@ from sklearn.ensemble import AdaBoostClassifier as SKLModel
 import lale.docstrings
 import lale.operators
 
+from .fit_spec_proxy import _FitSpecProxy
 from .function_transformer import FunctionTransformer
-
-
-class FitSpecProxy:
-    def __init__(self, base):
-        self._base = base
-
-    def __getattr__(self, item):
-        return getattr(self._base, item)
-
-    def get_params(self, deep=True):
-        ret = {}
-        ret["base"] = self._base
-        return ret
-
-    def fit(self, X, y, sample_weight=None, **fit_params):
-        return self._base.fit(X, y, sample_weight=sample_weight, **fit_params)
 
 
 class _AdaBoostClassifierImpl:
     def __init__(
         self,
         base_estimator=None,
+        *,
         n_estimators=50,
         learning_rate=1.0,
         algorithm="SAMME.R",
@@ -49,7 +35,7 @@ class _AdaBoostClassifierImpl:
         if base_estimator is None:
             estimator_impl = None
         else:
-            estimator_impl = FitSpecProxy(base_estimator)
+            estimator_impl = _FitSpecProxy(base_estimator)
 
         self._hyperparams = {
             "base_estimator": estimator_impl,
@@ -74,7 +60,7 @@ class _AdaBoostClassifierImpl:
                 inverse_func=None,
                 check_inverse=False,
             )
-            self._hyperparams["base_estimator"] = FitSpecProxy(
+            self._hyperparams["base_estimator"] = _FitSpecProxy(
                 feature_transformer >> self._hyperparams["base_estimator"]
             )
             self._wrapped_model = SKLModel(**self._hyperparams)

--- a/lale/lib/sklearn/ada_boost_regressor.py
+++ b/lale/lib/sklearn/ada_boost_regressor.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pandas as pd
 from sklearn.ensemble import AdaBoostRegressor as SKLModel
 
 import lale.docstrings
 import lale.operators
 from lale.lib.sklearn.ada_boost_classifier import FitSpecProxy
+
+from .function_transformer import FunctionTransformer
 
 
 class _AdaBoostRegressorImpl:
@@ -50,6 +53,16 @@ class _AdaBoostRegressorImpl:
         return out
 
     def fit(self, X, y=None):
+        if isinstance(X, pd.DataFrame):
+            feature_transformer = FunctionTransformer(
+                func=lambda X_prime: pd.DataFrame(X_prime, columns=X.columns),
+                inverse_func=None,
+                check_inverse=False,
+            )
+            self._hyperparams["base_estimator"] = FitSpecProxy(
+                feature_transformer >> self._hyperparams["base_estimator"]
+            )
+            self._wrapped_model = SKLModel(**self._hyperparams)
         if y is not None:
             self._wrapped_model.fit(X, y)
         else:

--- a/lale/lib/sklearn/ada_boost_regressor.py
+++ b/lale/lib/sklearn/ada_boost_regressor.py
@@ -17,8 +17,8 @@ from sklearn.ensemble import AdaBoostRegressor as SKLModel
 
 import lale.docstrings
 import lale.operators
-from lale.lib.sklearn.ada_boost_classifier import FitSpecProxy
 
+from .fit_spec_proxy import _FitSpecProxy
 from .function_transformer import FunctionTransformer
 
 
@@ -26,6 +26,7 @@ class _AdaBoostRegressorImpl:
     def __init__(
         self,
         base_estimator=None,
+        *,
         n_estimators=50,
         learning_rate=1.0,
         loss="linear",
@@ -34,7 +35,7 @@ class _AdaBoostRegressorImpl:
         if base_estimator is None:
             estimator_impl = None
         else:
-            estimator_impl = FitSpecProxy(base_estimator)
+            estimator_impl = _FitSpecProxy(base_estimator)
 
         self._hyperparams = {
             "base_estimator": estimator_impl,
@@ -59,7 +60,7 @@ class _AdaBoostRegressorImpl:
                 inverse_func=None,
                 check_inverse=False,
             )
-            self._hyperparams["base_estimator"] = FitSpecProxy(
+            self._hyperparams["base_estimator"] = _FitSpecProxy(
                 feature_transformer >> self._hyperparams["base_estimator"]
             )
             self._wrapped_model = SKLModel(**self._hyperparams)

--- a/lale/lib/sklearn/bagging_classifier.py
+++ b/lale/lib/sklearn/bagging_classifier.py
@@ -26,6 +26,7 @@ class _BaggingClassifierImpl:
         self,
         base_estimator=None,
         n_estimators=10,
+        *,
         max_samples=1.0,
         max_features=1.0,
         bootstrap=True,
@@ -230,9 +231,12 @@ _input_fit_schema = {
             "description": "The training input samples. Sparse matrices are accepted only if",
         },
         "y": {
-            "type": "array",
-            "items": {"type": "number"},
-            "description": "The target values (class labels in classification, real numbers in",
+            "anyOf": [
+                {"type": "array", "items": {"type": "number"}},
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "array", "items": {"type": "boolean"}},
+            ],
+            "description": "The target values (class labels).",
         },
         "sample_weight": {
             "anyOf": [

--- a/lale/lib/sklearn/bagging_regressor.py
+++ b/lale/lib/sklearn/bagging_regressor.py
@@ -21,7 +21,7 @@ import lale.operators
 from .function_transformer import FunctionTransformer
 
 
-class _BaggingClassifierImpl:
+class _BaggingRegressorImpl:
     def __init__(
         self,
         base_estimator=None,
@@ -78,18 +78,12 @@ class _BaggingClassifierImpl:
     def predict(self, X):
         return self._wrapped_model.predict(X)
 
-    def predict_proba(self, X):
-        return self._wrapped_model.predict_proba(X)
-
-    def decision_function(self, X):
-        return self._wrapped_model.decision_function(X)
-
     def score(self, X, y, sample_weight=None):
         return self._wrapped_model.score(X, y, sample_weight)
 
 
 _hyperparams_schema = {
-    "description": "A Bagging classifier.",
+    "description": "A Bagging regressor.",
     "allOf": [
         {
             "type": "object",
@@ -266,59 +260,8 @@ _output_predict_schema = {
     "items": {"type": "number"},
 }
 
-_input_predict_proba_schema = {
-    "type": "object",
-    "required": ["X"],
-    "properties": {
-        "X": {
-            "type": "array",
-            "items": {
-                "type": "array",
-                "items": {"type": "number"},
-            },
-            "description": "The training input samples. Sparse matrices are accepted only if",
-        },
-    },
-}
-
-_output_predict_proba_schema = {
-    "type": "array",
-    "items": {
-        "type": "array",
-        "items": {"type": "number"},
-    },
-}
-
-_input_decision_function_schema = {
-    "type": "object",
-    "required": ["X"],
-    "additionalProperties": False,
-    "properties": {
-        "X": {
-            "description": "Features; the outer array is over samples.",
-            "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
-        }
-    },
-}
-
-_output_decision_function_schema = {
-    "anyOf": [
-        {
-            "description": "In the multi-way case, score per (sample, class) combination.",
-            "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
-        },
-        {
-            "description": "In the binary case, score for `self._classes[1]`.",
-            "type": "array",
-            "items": {"type": "number"},
-        },
-    ],
-}
-
 _input_score_schema = {
-    "description": "Return the mean accuracy on the given test data and labels.",
+    "description": "Return the coefficient of determination R^2 of the prediction.",
     "type": "object",
     "required": ["X", "y"],
     "properties": {
@@ -328,12 +271,12 @@ _input_score_schema = {
                 "type": "array",
                 "items": {"type": "number"},
             },
-            "description": "Test samples.",
+            "description": "Test samples. For some estimators this may be a precomputed kernel matrix or a list of generic objects instead with shape (n_samples, n_samples_fitted), where n_samples_fitted is the number of samples used in the fitting for the estimator.",
         },
         "y": {
             "type": "array",
             "items": {"type": "number"},
-            "description": "True labels for 'X'.",
+            "description": "True values for 'X'.",
         },
         "sample_weight": {
             "anyOf": [
@@ -348,7 +291,7 @@ _input_score_schema = {
     },
 }
 _output_score_schema = {
-    "description": "Mean accuracy of 'self.predict' wrt 'y'",
+    "description": "R^2 of 'self.predict' wrt 'y'",
     "type": "number",
 }
 
@@ -367,18 +310,14 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
-        "input_predict_proba": _input_predict_proba_schema,
-        "output_predict_proba": _output_predict_proba_schema,
-        "input_decision_function": _input_decision_function_schema,
-        "output_decision_function": _output_decision_function_schema,
         "input_score": _input_score_schema,
         "output_score": _output_score_schema,
     },
 }
 
 
-BaggingClassifier = lale.operators.make_operator(
-    _BaggingClassifierImpl, _combined_schemas
+BaggingRegressor = lale.operators.make_operator(
+    _BaggingRegressorImpl, _combined_schemas
 )
 
-lale.docstrings.set_docstrings(BaggingClassifier)
+lale.docstrings.set_docstrings(BaggingRegressor)

--- a/lale/lib/sklearn/bagging_regressor.py
+++ b/lale/lib/sklearn/bagging_regressor.py
@@ -26,6 +26,7 @@ class _BaggingRegressorImpl:
         self,
         base_estimator=None,
         n_estimators=10,
+        *,
         max_samples=1.0,
         max_features=1.0,
         bootstrap=True,

--- a/lale/lib/sklearn/bagging_regressor.py
+++ b/lale/lib/sklearn/bagging_regressor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pandas as pd
-from sklearn.ensemble import BaggingClassifier as SKLModel
+from sklearn.ensemble import BaggingRegressor as SKLModel
 
 import lale.docstrings
 import lale.operators

--- a/lale/lib/sklearn/fit_spec_proxy.py
+++ b/lale/lib/sklearn/fit_spec_proxy.py
@@ -1,0 +1,14 @@
+class _FitSpecProxy:
+    def __init__(self, base):
+        self._base = base
+
+    def __getattr__(self, item):
+        return getattr(self._base, item)
+
+    def get_params(self, deep=True):
+        ret = {}
+        ret["base"] = self._base
+        return ret
+
+    def fit(self, X, y, sample_weight=None, **fit_params):
+        return self._base.fit(X, y, sample_weight=sample_weight, **fit_params)

--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -79,18 +79,20 @@ _hyperparams_schema = {
                     "description": "A classifier which will be used to combine the base estimators. The default classifier is a 'LogisticRegression'",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {
-                            "type": "integer",
-                            "minimumForOptimizer": 3,
-                            "maximumForOptimizer": 4,
-                            "distribution": "uniform",
-                        },
-                        {"enum": [None]},
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "default": None,
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "stack_method": {
                     "description": "Methods called for each base estimator. If ‘auto’, it will try to invoke, for each estimator, 'predict_proba', 'decision_function' or 'predict' in that order. Otherwise, one of 'predict_proba', 'decision_function' or 'predict'. If the method is not implemented by the estimator, it will raise an error.",
@@ -125,9 +127,12 @@ _input_fit_schema = {
             "description": "Training vectors, where n_samples is the number of samples and n_features is the number of features.",
         },
         "y": {
-            "type": "array",
-            "items": {"type": "number"},
-            "description": "Target values.",
+            "anyOf": [
+                {"type": "array", "items": {"type": "number"}},
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "array", "items": {"type": "boolean"}},
+            ],
+            "description": "The target values (class labels).",
         },
         "sample_weight": {
             "anyOf": [

--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -18,70 +18,14 @@ from sklearn.ensemble import StackingClassifier as SKLModel
 import lale.docstrings
 import lale.operators
 
-from .decision_tree_classifier import DecisionTreeClassifier
 from .stacking_utils import _concatenate_predictions_pandas
 
 
-class _StackingClassifierSubclass(SKLModel):
+class _StackingClassifierImpl(SKLModel):
     def _concatenate_predictions(self, X, predictions):
-        if not isinstance(X, pd.DataFrame) and not self.passthrough:
+        if not isinstance(X, pd.DataFrame):
             return super()._concatenate_predictions(X, predictions)
         return _concatenate_predictions_pandas(self, X, predictions)
-
-
-class _StackingClassifierImpl:
-    def __init__(
-        self,
-        estimators,
-        final_estimator=None,
-        cv=None,
-        stack_method="auto",
-        n_jobs=None,
-        passthrough=False,
-        verbose=0,
-    ):
-        estimator_impls = estimators
-        if final_estimator is None:
-            final_estimator = DecisionTreeClassifier()
-        self._hyperparams = {
-            "estimators": estimator_impls,
-            "final_estimator": final_estimator,
-            "cv": cv,
-            "stack_method": stack_method,
-            "n_jobs": n_jobs,
-            "passthrough": passthrough,
-            "verbose": verbose,
-        }
-        self._wrapped_model = _StackingClassifierSubclass(**self._hyperparams)
-        self._hyperparams["estimators"] = estimators
-
-    def get_params(self, deep=True):
-        out = self._wrapped_model.get_params(deep=deep)
-        # we want to return the lale operators, not the underlying impls
-        out["estimators"] = self._hyperparams["estimators"]
-        return out
-
-    def fit(self, X, y, sample_weight=None):
-        self._wrapped_model.fit(X, y, sample_weight)
-        return self
-
-    def predict(self, X, **predict_params):
-        return self._wrapped_model.predict(X, **predict_params)
-
-    def predict_proba(self, X):
-        return self._wrapped_model.predict_proba(X)
-
-    def decision_function(self, X):
-        return self._wrapped_model.decision_function(X)
-
-    def score(self, X, y, sample_weight=None):
-        return self._wrapped_model.score(X, y, sample_weight)
-
-    def fit_transform(self, X, y=None):
-        return self._wrapped_model.fit(X, y)
-
-    def transform(self, X):
-        return self._wrapped_model.transform(X)
 
 
 _hyperparams_schema = {

--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -62,13 +62,7 @@ _hyperparams_schema = {
                     "description": "Base estimators which will be stacked together. Each element of the list is defined as a tuple of string (i.e. name) and an estimator instance. An estimator can be set to ‘drop’ using set_params.",
                 },
                 "final_estimator": {
-                    "anyOf": [
-                        {"laleType": "operator", "enum": [None]},
-                        {
-                            "enum": [None],
-                            "description": "A classifier which will be used to combine the base estimators. The default classifier is a 'LogisticRegression'",
-                        },
-                    ],
+                    "anyOf": [{"laleType": "operator"}, {"enum": [None]}],
                     "default": None,
                     "description": "A classifier which will be used to combine the base estimators. The default classifier is a 'LogisticRegression'",
                 },

--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -88,11 +88,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "stack_method": {
                     "description": "Methods called for each base estimator. If ‘auto’, it will try to invoke, for each estimator, 'predict_proba', 'decision_function' or 'predict' in that order. Otherwise, one of 'predict_proba', 'decision_function' or 'predict'. If the method is not implemented by the estimator, it will raise an error.",

--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sklearn.ensemble
+import pandas as pd
+from sklearn.ensemble import StackingClassifier as SKLModel
 
 import lale.docstrings
 import lale.operators
+
+from .stacking_utils import _BaseStackingLale
+
+
+class _StackingClassifierImpl(SKLModel, _BaseStackingLale):
+    def _concatenate_predictions(self, X, predictions):
+        if not isinstance(X, pd.DataFrame) and not self.passthrough:
+            return super()._concatenate_predictions(X, predictions)
+        return self._concatenate_predictions_pandas(X, predictions)
+
 
 _hyperparams_schema = {
     "description": "Stack of estimators with a final classifier.",
@@ -233,5 +244,5 @@ _combined_schemas = {
 
 StackingClassifier: lale.operators.PlannedIndividualOp
 StackingClassifier = lale.operators.make_operator(
-    sklearn.ensemble.StackingClassifier, _combined_schemas
+    _StackingClassifierImpl, _combined_schemas
 )

--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -22,6 +22,18 @@ from .stacking_utils import _concatenate_predictions_pandas
 
 
 class _StackingClassifierImpl(SKLModel):
+    def predict(self, X):
+        return super().predict(X)
+
+    def predict_proba(self, X):
+        return super().predict_proba(X)
+
+    def score(self, X, y, sample_weight=None):
+        return super().score(X, y, sample_weight)
+
+    def decision_function(X):
+        return super().decision_function(X)
+
     def _concatenate_predictions(self, X, predictions):
         if not isinstance(X, pd.DataFrame):
             return super()._concatenate_predictions(X, predictions)

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -1,0 +1,224 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.ensemble
+
+import lale.docstrings
+import lale.operators
+
+_hyperparams_schema = {
+    "description": "Stack of estimators with a final regressor.",
+    "allOf": [
+        {
+            "type": "object",
+            "required": [
+                "estimators",
+                "final_estimator",
+                "cv",
+                "n_jobs",
+                "passthrough",
+            ],
+            "relevantToOptimizer": [
+                "estimators",
+                "final_estimator",
+                "cv",
+                "passthrough",
+            ],
+            "additionalProperties": False,
+            "properties": {
+                "estimators": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "laleType": "tuple",
+                        "items": [
+                            {"type": "string"},
+                            {"anyOf": [{"laleType": "operator"}, {"enum": [None]}]},
+                        ],
+                    },
+                    "description": "Base estimators which will be stacked together. Each element of the list is defined as a tuple of string (i.e. name) and an estimator instance. An estimator can be set to ‘drop’ using set_params.",
+                },
+                "final_estimator": {
+                    "laleType": "operator",
+                    "default": "None",
+                    "description": "A regressor which will be used to combine the base estimators. The default regressor is a 'RidgeCV'",
+                },
+                "cv": {
+                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
+                    "description": "Determines the cross-validation splitting strategy",
+                    "anyOf": [
+                        {
+                            "type": "integer",
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
+                        {"enum": [None]},
+                    ],
+                    "default": None,
+                },
+                "n_jobs": {
+                    "anyOf": [{"type": "integer"}, {"enum": [None]}],
+                    "default": None,
+                    "description": "The number of jobs to run in parallel for ``fit``.",
+                },
+                "passthrough": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "When False, only the predictions of estimators will be used as training data for 'final_estimator'. When True, the 'final_estimator' is trained on the predictions as well as the original training data.",
+                },
+            },
+        },
+    ],
+}
+_input_fit_schema = {
+    "description": "Fit the estimators.",
+    "type": "object",
+    "required": ["X", "y"],
+    "properties": {
+        "X": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "number"},
+            },
+            "description": "Training vectors, where n_samples is the number of samples and n_features is the number of features.",
+        },
+        "y": {
+            "type": "array",
+            "items": {"type": "number"},
+            "description": "Target values.",
+        },
+        "sample_weight": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {"type": "number"},
+                },
+                {"enum": [None]},
+            ],
+            "description": "Sample weights. If None, then samples are equally weighted.",
+        },
+    },
+}
+_input_transform_schema = {
+    "description": "Fit to data, then transform it.",
+    "type": "object",
+    "properties": {
+        "X": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "number"},
+            },
+            "description": "Training vectors, where n_samples is the number of samples and n_features is the number of features",
+        },
+    },
+}
+_output_transform_schema = {
+    "description": "Transformed array",
+    "type": "array",
+    "items": {
+        "type": "array",
+        "items": {
+            "anyOf": [
+                {"type": "number"},
+                {"type": "array", "items": {"type": "number"}},
+            ]
+        },
+    },
+}
+
+_input_predict_schema = {
+    "description": "Predict target for X.",
+    "type": "object",
+    "properties": {
+        "X": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "number"},
+            },
+            "description": "The input samples.",
+        },
+    },
+}
+_output_predict_schema = {
+    "description": "Predicted targets.",
+    "type": "array",
+    "items": {"type": "number"},
+}
+
+_input_score_schema = {
+    "description": "Return the coefficient of determination R^2 of the prediction.",
+    "type": "object",
+    "required": ["X", "y"],
+    "properties": {
+        "X": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "number"},
+            },
+            "description": "Test samples. For some estimators this may be a precomputed kernel matrix or a list of generic objects instead with shape (n_samples, n_samples_fitted), where n_samples_fitted is the number of samples used in the fitting for the estimator.",
+        },
+        "y": {
+            "type": "array",
+            "items": {"type": "number"},
+            "description": "True values for 'X'.",
+        },
+        "sample_weight": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {"type": "number"},
+                },
+                {"enum": [None]},
+            ],
+            "description": "Sample weights. If None, then samples are equally weighted.",
+        },
+    },
+}
+_output_score_schema = {
+    "description": "R^2 of 'self.predict' wrt 'y'",
+    "type": "number",
+}
+
+
+_combined_schemas = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": """`Stacking regressor`_ from scikit-learn for stacking ensemble.
+
+.. _`Stacking regressor`: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingRegressor.html
+""",
+    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.sklearn.stacking_regressor.html",
+    "import_from": "sklearn.ensemble",
+    "type": "object",
+    "tags": {"pre": [], "op": ["transformer", "estimator"], "post": []},
+    "properties": {
+        "hyperparams": _hyperparams_schema,
+        "input_fit": _input_fit_schema,
+        "input_predict": _input_predict_schema,
+        "output_predict": _output_predict_schema,
+        "input_score_schema": _input_score_schema,
+        "output_score_schema": _output_score_schema,
+        "input_transform": _input_transform_schema,
+        "output_transform": _output_transform_schema,
+    },
+}
+
+StackingRegressor: lale.operators.PlannedIndividualOp
+StackingRegressor = lale.operators.make_operator(
+    sklearn.ensemble.StackingRegressor, _combined_schemas
+)

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -81,11 +81,16 @@ _hyperparams_schema = {
                         as arrays of indices. Can use any of the iterators from
                         https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {"type": "integer"},
+                        {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 5,
+                            "minimumForOptimizer": 3,
+                            "maximumForOptimizer": 4,
+                            "distribution": "uniform",
+                        },
                         {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "minimum": 1,
-                    "default": 5,
                 },
                 "n_jobs": {
                     "anyOf": [{"type": "integer"}, {"enum": [None]}],

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sklearn.ensemble
+import pandas as pd
+from sklearn.ensemble import StackingRegressor as SKLModel
 
 import lale.docstrings
 import lale.operators
+
+from .stacking_utils import _BaseStackingLale
+
+
+class _StackingRegressorImpl(SKLModel, _BaseStackingLale):
+    def _concatenate_predictions(self, X, predictions):
+        if not isinstance(X, pd.DataFrame) and not self.passthrough:
+            return super()._concatenate_predictions(X, predictions)
+        return self._concatenate_predictions_pandas(X, predictions)
+
 
 _hyperparams_schema = {
     "description": "Stack of estimators with a final regressor.",
@@ -220,5 +231,5 @@ _combined_schemas = {
 
 StackingRegressor: lale.operators.PlannedIndividualOp
 StackingRegressor = lale.operators.make_operator(
-    sklearn.ensemble.StackingRegressor, _combined_schemas
+    _StackingRegressorImpl, _combined_schemas
 )

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -18,14 +18,14 @@ from sklearn.ensemble import StackingRegressor as SKLModel
 import lale.docstrings
 import lale.operators
 
-from .stacking_utils import _BaseStackingLale
+from .stacking_utils import _concatenate_predictions_pandas
 
 
-class _StackingRegressorImpl(SKLModel, _BaseStackingLale):
+class _StackingRegressorImpl(SKLModel):
     def _concatenate_predictions(self, X, predictions):
         if not isinstance(X, pd.DataFrame) and not self.passthrough:
             return super()._concatenate_predictions(X, predictions)
-        return self._concatenate_predictions_pandas(X, predictions)
+        return _concatenate_predictions_pandas(self, X, predictions)
 
 
 _hyperparams_schema = {
@@ -61,9 +61,15 @@ _hyperparams_schema = {
                     "description": "Base estimators which will be stacked together. Each element of the list is defined as a tuple of string (i.e. name) and an estimator instance. An estimator can be set to ‘drop’ using set_params.",
                 },
                 "final_estimator": {
-                    "laleType": "operator",
-                    "default": "None",
-                    "description": "A regressor which will be used to combine the base estimators. The default regressor is a 'RidgeCV'",
+                    "anyOf": [
+                        {"laleType": "operator", "enum": [None]},
+                        {
+                            "enum": [None],
+                            "description": "A regressor which will be used to combine the base estimators. The default classifier is a 'RidgeCV'",
+                        },
+                    ],
+                    "default": None,
+                    "description": "A regressor which will be used to combine the base estimators. The default classifier is a 'RidgeCV'",
                 },
                 "cv": {
                     "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -23,7 +23,7 @@ from .stacking_utils import _concatenate_predictions_pandas
 
 class _StackingRegressorImpl(SKLModel):
     def _concatenate_predictions(self, X, predictions):
-        if not isinstance(X, pd.DataFrame) and not self.passthrough:
+        if not isinstance(X, pd.DataFrame):
             return super()._concatenate_predictions(X, predictions)
         return _concatenate_predictions_pandas(self, X, predictions)
 

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -72,18 +72,20 @@ _hyperparams_schema = {
                     "description": "A regressor which will be used to combine the base estimators. The default classifier is a 'RidgeCV'",
                 },
                 "cv": {
-                    "XXX TODO XXX": "int, cross-validation generator or an iterable, optional",
-                    "description": "Determines the cross-validation splitting strategy",
+                    "description": """Cross-validation as integer or as object that has a split function.
+                        The fit method performs cross validation on the input dataset for per
+                        trial, and uses the mean cross validation performance for optimization.
+                        This behavior is also impacted by handle_cv_failure flag.
+                        If integer: number of folds in sklearn.model_selection.StratifiedKFold.
+                        If object with split function: generator yielding (train, test) splits
+                        as arrays of indices. Can use any of the iterators from
+                        https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation-iterators.""",
                     "anyOf": [
-                        {
-                            "type": "integer",
-                            "minimumForOptimizer": 3,
-                            "maximumForOptimizer": 4,
-                            "distribution": "uniform",
-                        },
-                        {"enum": [None]},
+                        {"type": "integer"},
+                        {"laleType": "Any", "forOptimizer": False},
                     ],
-                    "default": None,
+                    "minimum": 1,
+                    "default": 5,
                 },
                 "n_jobs": {
                     "anyOf": [{"type": "integer"}, {"enum": [None]}],

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -22,6 +22,12 @@ from .stacking_utils import _concatenate_predictions_pandas
 
 
 class _StackingRegressorImpl(SKLModel):
+    def predict(self, X):
+        return super().predict(X)
+
+    def score(self, X, y, sample_weight=None):
+        return super().score(X, y, sample_weight)
+
     def _concatenate_predictions(self, X, predictions):
         if not isinstance(X, pd.DataFrame):
             return super()._concatenate_predictions(X, predictions)

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -61,13 +61,7 @@ _hyperparams_schema = {
                     "description": "Base estimators which will be stacked together. Each element of the list is defined as a tuple of string (i.e. name) and an estimator instance. An estimator can be set to ‘drop’ using set_params.",
                 },
                 "final_estimator": {
-                    "anyOf": [
-                        {"laleType": "operator", "enum": [None]},
-                        {
-                            "enum": [None],
-                            "description": "A regressor which will be used to combine the base estimators. The default classifier is a 'RidgeCV'",
-                        },
-                    ],
+                    "anyOf": [{"laleType": "operator"}, {"enum": [None]}],
                     "default": None,
                     "description": "A regressor which will be used to combine the base estimators. The default classifier is a 'RidgeCV'",
                 },

--- a/lale/lib/sklearn/stacking_utils.py
+++ b/lale/lib/sklearn/stacking_utils.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from sklearn.ensemble._stacking import _BaseStacking
+
+
+class _BaseStackingLale(_BaseStacking):
+    def _concatenate_predictions_pandas(self, X, predictions):
+        X_meta = []
+        idx = 0
+        for est_idx, preds in enumerate(predictions):
+            # case where the the estimator returned a 1D array
+            if preds.ndim == 1:
+                X_meta.append(preds.reshape(-1, 1))
+            else:
+                if (
+                    self.stack_method_[est_idx] == "predict_proba"
+                    and len(self.classes_) == 2
+                ):
+                    # Remove the first column when using probabilities in
+                    # binary classification because both features are perfectly
+                    # collinear.
+                    X_meta.append(preds[:, 1:])
+                else:
+                    X_meta.append(preds)
+            X_meta[-1] = pd.DataFrame(
+                X_meta[-1],
+                columns=[
+                    f"estimator_{idx}_feature_{i}" for i in range(X_meta[-1].shape[1])
+                ],
+            )
+            idx += 1
+        if self.passthrough:
+            X_meta.append(X)
+
+        return pd.concat(X_meta, axis=1)

--- a/lale/lib/sklearn/stacking_utils.py
+++ b/lale/lib/sklearn/stacking_utils.py
@@ -1,34 +1,31 @@
 import pandas as pd
-from sklearn.ensemble._stacking import _BaseStacking
 
 
-class _BaseStackingLale(_BaseStacking):
-    def _concatenate_predictions_pandas(self, X, predictions):
-        X_meta = []
-        idx = 0
-        for est_idx, preds in enumerate(predictions):
-            # case where the the estimator returned a 1D array
-            if preds.ndim == 1:
-                X_meta.append(preds.reshape(-1, 1))
+def _concatenate_predictions_pandas(base_stacking, X, predictions):
+    X_meta = []
+    idx = 0
+    for est_idx, preds in enumerate(predictions):
+        # case where the the estimator returned a 1D array
+        if preds.ndim == 1:
+            X_meta.append(preds.reshape(-1, 1))
+        else:
+            if (
+                base_stacking.stack_method_[est_idx] == "predict_proba"
+                and len(base_stacking.classes_) == 2
+            ):
+                # Remove the first column when using probabilities in
+                # binary classification because both features are perfectly
+                # collinear.
+                X_meta.append(preds[:, 1:])
             else:
-                if (
-                    self.stack_method_[est_idx] == "predict_proba"
-                    and len(self.classes_) == 2
-                ):
-                    # Remove the first column when using probabilities in
-                    # binary classification because both features are perfectly
-                    # collinear.
-                    X_meta.append(preds[:, 1:])
-                else:
-                    X_meta.append(preds)
-            X_meta[-1] = pd.DataFrame(
-                X_meta[-1],
-                columns=[
-                    f"estimator_{idx}_feature_{i}" for i in range(X_meta[-1].shape[1])
-                ],
-            )
-            idx += 1
-        if self.passthrough:
-            X_meta.append(X)
-
-        return pd.concat(X_meta, axis=1)
+                X_meta.append(preds)
+        X_meta[-1] = pd.DataFrame(
+            X_meta[-1],
+            columns=[
+                f"estimator_{idx}_feature_{i}" for i in range(X_meta[-1].shape[1])
+            ],
+        )
+        idx += 1
+    if base_stacking.passthrough:
+        X_meta.append(X)
+    return pd.concat(X_meta, axis=1)

--- a/lale/lib/sklearn/voting_classifier.py
+++ b/lale/lib/sklearn/voting_classifier.py
@@ -258,7 +258,7 @@ VotingClassifier = lale.operators.make_operator(
 )
 
 if sklearn.__version__ >= "0.21":
-    # old: https://scikit-learn.org/0.20/modules/generated/sklearn.ensemble.VotingClassifier.html
+    # old: N/A (new in this version)
     # new: https://scikit-learn.org/0.21/modules/generated/sklearn.ensemble.VotingClassifier.html
     VotingClassifier = VotingClassifier.customize_schema(
         estimators={

--- a/lale/lib/sklearn/voting_classifier.py
+++ b/lale/lib/sklearn/voting_classifier.py
@@ -113,9 +113,12 @@ _input_fit_schema = {
             "description": "Training vectors, where n_samples is the number of samples and n_features is the number of features.",
         },
         "y": {
-            "type": "array",
-            "items": {"type": "number"},
-            "description": "Target values.",
+            "anyOf": [
+                {"type": "array", "items": {"type": "number"}},
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "array", "items": {"type": "boolean"}},
+            ],
+            "description": "The target values (class labels).",
         },
         "sample_weight": {
             "anyOf": [

--- a/lale/lib/sklearn/voting_regressor.py
+++ b/lale/lib/sklearn/voting_regressor.py
@@ -236,15 +236,15 @@ _combined_schemas = {
     },
 }
 
-VotingClassifier: lale.operators.PlannedIndividualOp
-VotingClassifier = lale.operators.make_operator(
+VotingRegressor: lale.operators.PlannedIndividualOp
+VotingRegressor = lale.operators.make_operator(
     sklearn.ensemble.VotingRegressor, _combined_schemas
 )
 
 if sklearn.__version__ >= "0.21":
-    # old: https://scikit-learn.org/0.20/modules/generated/sklearn.ensemble.VotingClassifier.html
-    # new: https://scikit-learn.org/0.21/modules/generated/sklearn.ensemble.VotingClassifier.html
-    VotingClassifier = VotingClassifier.customize_schema(
+    # old: https://scikit-learn.org/0.20/modules/generated/sklearn.ensemble.VotingRegressor.html
+    # new: https://scikit-learn.org/0.21/modules/generated/sklearn.ensemble.VotingRegressor.html
+    VotingRegressor = VotingRegressor.customize_schema(
         estimators={
             "type": "array",
             "items": {
@@ -255,14 +255,14 @@ if sklearn.__version__ >= "0.21":
                     {"anyOf": [{"laleType": "operator"}, {"enum": [None, "drop"]}]},
                 ],
             },
-            "description": "List of (string, estimator) tuples. Invoking the ``fit`` method on the ``VotingClassifier`` will fit clones.",
+            "description": "List of (string, estimator) tuples. Invoking the ``fit`` method on the ``VotingRegressor`` will fit clones.",
         }
     )
 
 if sklearn.__version__ >= "0.24":
-    # old: https://scikit-learn.org/0.21/modules/generated/sklearn.ensemble.VotingClassifier.html
-    # new: https://scikit-learn.org/0.24/modules/generated/sklearn.ensemble.VotingClassifier.html
-    VotingClassifier = VotingClassifier.customize_schema(
+    # old: https://scikit-learn.org/0.21/modules/generated/sklearn.ensemble.VotingRegressor.html
+    # new: https://scikit-learn.org/0.24/modules/generated/sklearn.ensemble.VotingRegressor.html
+    VotingRegressor = VotingRegressor.customize_schema(
         estimators={
             "type": "array",
             "items": {
@@ -278,4 +278,4 @@ if sklearn.__version__ >= "0.24":
     )
 
 
-lale.docstrings.set_docstrings(VotingClassifier)
+lale.docstrings.set_docstrings(VotingRegressor)

--- a/lale/lib/sklearn/voting_regressor.py
+++ b/lale/lib/sklearn/voting_regressor.py
@@ -13,31 +13,22 @@
 # limitations under the License.
 
 import sklearn
-from sklearn.ensemble import VotingClassifier as SKLModel
+import sklearn.ensemble
 
 import lale.docstrings
 import lale.operators
 
-
-class _VotingClassifierImpl(SKLModel):
-    # defining predict_proba regardless of whether classification is 'hard' or 'soft'
-    def predict_proba(self, X):
-        return self._predict_proba(X)
-
-
 _hyperparams_schema = {
-    "description": "Soft Voting/Majority Rule classifier for unfitted estimators.",
+    "description": "Prediction voting regressor for unfitted estimators.",
     "allOf": [
         {
             "type": "object",
             "required": [
                 "estimators",
-                "voting",
                 "weights",
                 "n_jobs",
-                "flatten_transform",
             ],
-            "relevantToOptimizer": ["voting"],
+            "relevantToOptimizer": ["weights"],
             "additionalProperties": False,
             "properties": {
                 "estimators": {
@@ -51,11 +42,6 @@ _hyperparams_schema = {
                         ],
                     },
                     "description": "List of (string, estimator) tuples. Invoking the ``fit`` method on the ``VotingClassifier`` will fit clones.",
-                },
-                "voting": {
-                    "enum": ["hard", "soft"],
-                    "default": "hard",
-                    "description": "If 'hard', uses predicted class labels for majority rule voting.",
                 },
                 "weights": {
                     "anyOf": [
@@ -73,29 +59,7 @@ _hyperparams_schema = {
                     "default": None,
                     "description": "The number of jobs to run in parallel for ``fit``.",
                 },
-                "flatten_transform": {
-                    "type": "boolean",
-                    "default": True,
-                    "description": "Affects shape of transform output only when voting='soft'",
-                },
             },
-        },
-        {
-            "description": "Parameter: flatten_transform > only when voting='soft' if voting='soft' and flatten_transform=true",
-            "anyOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "voting": {"enum": ["soft"]},
-                    },
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "flatten_transform": {"enum": [True]},
-                    },
-                },
-            ],
         },
     ],
 }
@@ -110,7 +74,7 @@ _input_fit_schema = {
                 "type": "array",
                 "items": {"type": "number"},
             },
-            "description": "Training vectors, where n_samples is the number of samples and n_features is the number of features.",
+            "description": "Input samples.",
         },
         "y": {
             "type": "array",
@@ -129,8 +93,8 @@ _input_fit_schema = {
         },
     },
 }
-_input_transform_schema = {
-    "description": "Return class labels or probabilities for X for each estimator.",
+_input_fit_transform_schema = {
+    "description": "Return class labels or probabilities for X for each estimator. Return predictions for X for each estimator.",
     "type": "object",
     "properties": {
         "X": {
@@ -139,12 +103,48 @@ _input_transform_schema = {
                 "type": "array",
                 "items": {"type": "number"},
             },
-            "description": "Training vectors, where n_samples is the number of samples and",
+            "description": "Input samples",
+        },
+        "y": {
+            "type": "array",
+            "items": {"type": "number"},
+            "default": "None",
+            "description": "Target values. (None for unsupervised transformations.)",
+        },
+        "**fit_params": {
+            "type": "dictionary",
+            "items": [{"type": "string"}],
+            "description": "Additional fit parameters.",
+        },
+    },
+}
+_output_fit_transform_schema = {
+    "description": "Transformed array.",
+    "type": "array",
+    "items": {
+        "type": "array",
+        "items": {
+            "type": "array",
+            "items": {"type": "number"},
+        },
+    },
+}
+_input_transform_schema = {
+    "description": "Return predictions for X for each estimator.",
+    "type": "object",
+    "properties": {
+        "X": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"type": "number"},
+            },
+            "description": "Input samples",
         },
     },
 }
 _output_transform_schema = {
-    "description": "If `voting='soft'` and `flatten_transform=True`:",
+    "description": "Values predicted by each regressor",
     "type": "array",
     "items": {
         "type": "array",
@@ -176,9 +176,10 @@ _output_predict_schema = {
     "type": "array",
     "items": {"type": "number"},
 }
-_input_predict_proba_schema = {
-    "description": "Compute probabilities of possible outcomes for samples in X.",
+_input_score_schema = {
+    "description": "Return the coefficient of determination R^2 of the prediction.",
     "type": "object",
+    "required": ["X", "y"],
     "properties": {
         "X": {
             "type": "array",
@@ -186,47 +187,30 @@ _input_predict_proba_schema = {
                 "type": "array",
                 "items": {"type": "number"},
             },
-            "description": "The input samples.",
+            "description": "Test samples. For some estimators this may be a precomputed kernel matrix or a list of generic objects instead with shape (n_samples, n_samples_fitted), where n_samples_fitted is the number of samples used in the fitting for the estimator.",
         },
-    },
-}
-_output_predict_proba_schema = {
-    "description": "Weighted average probability for each class per sample.",
-    "type": "array",
-    "items": {
-        "type": "array",
-        "items": {"type": "number"},
-    },
-}
-
-_input_decision_function_schema = {
-    "type": "object",
-    "required": ["X"],
-    "additionalProperties": False,
-    "properties": {
-        "X": {
-            "description": "Features; the outer array is over samples.",
-            "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
-        }
-    },
-}
-
-_output_decision_function_schema = {
-    "description": "Confidence scores for samples for each class in the model.",
-    "anyOf": [
-        {
-            "description": "In the multi-way case, score per (sample, class) combination.",
-            "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
-        },
-        {
-            "description": "In the binary case, score for `self._classes[1]`.",
+        "y": {
             "type": "array",
             "items": {"type": "number"},
+            "description": "True values for 'X'.",
         },
-    ],
+        "sample_weight": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {"type": "number"},
+                },
+                {"enum": [None]},
+            ],
+            "description": "Sample weights. If None, then samples are equally weighted.",
+        },
+    },
 }
+_output_score_schema = {
+    "description": "R^2 of 'self.predict' wrt 'y'",
+    "type": "number",
+}
+
 
 _combined_schemas = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -243,18 +227,18 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
-        "input_predict_proba": _input_predict_proba_schema,
-        "output_predict_proba": _output_predict_proba_schema,
+        "input_score_schema": _input_score_schema,
+        "output_score_schema": _output_score_schema,
         "input_transform": _input_transform_schema,
         "output_transform": _output_transform_schema,
-        "input_decision_function": _input_decision_function_schema,
-        "output_decision_function": _output_decision_function_schema,
+        "input_fit_transform": _input_fit_transform_schema,
+        "output_fit_transform": _output_fit_transform_schema,
     },
 }
 
 VotingClassifier: lale.operators.PlannedIndividualOp
 VotingClassifier = lale.operators.make_operator(
-    _VotingClassifierImpl, _combined_schemas
+    sklearn.ensemble.VotingRegressor, _combined_schemas
 )
 
 if sklearn.__version__ >= "0.21":

--- a/lale/lib/sklearn/voting_regressor.py
+++ b/lale/lib/sklearn/voting_regressor.py
@@ -111,11 +111,6 @@ _input_fit_transform_schema = {
             "default": "None",
             "description": "Target values. (None for unsupervised transformations.)",
         },
-        "**fit_params": {
-            "type": "dictionary",
-            "items": [{"type": "string"}],
-            "description": "Additional fit parameters.",
-        },
     },
 }
 _output_fit_transform_schema = {

--- a/lale/lib/sklearn/voting_regressor.py
+++ b/lale/lib/sklearn/voting_regressor.py
@@ -237,7 +237,7 @@ VotingRegressor = lale.operators.make_operator(
 )
 
 if sklearn.__version__ >= "0.21":
-    # old: https://scikit-learn.org/0.20/modules/generated/sklearn.ensemble.VotingRegressor.html
+    # old: N/A (new in this version)
     # new: https://scikit-learn.org/0.21/modules/generated/sklearn.ensemble.VotingRegressor.html
     VotingRegressor = VotingRegressor.customize_schema(
         estimators={

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -1336,6 +1336,8 @@ class IndividualOp(Operator):
         if name == "_estimator_type":
             if self.is_classifier():
                 return "classifier"  # satisfy sklearn.base.is_classifier(op)
+            elif self.is_regressor():
+                return "regressor"  # satisfy sklearn.base.is_regressor(op)
 
         return super().__getattr__(name)
 
@@ -1884,6 +1886,9 @@ class IndividualOp(Operator):
 
     def is_classifier(self) -> bool:
         return self.has_tag("classifier")
+
+    def is_regressor(self) -> bool:
+        return self.has_tag("regressor")
 
     def has_method(self, method_name: str) -> bool:
         return hasattr(self._impl, method_name)

--- a/test/test_core_classifiers.py
+++ b/test/test_core_classifiers.py
@@ -311,6 +311,55 @@ class TestBaggingClassifier(unittest.TestCase):
         _ = clf.auto_configure(self.X_train, self.y_train, Hyperopt, max_evals=1)
 
 
+class TestStackingClassifier(unittest.TestCase):
+    def setUp(self):
+        from sklearn.model_selection import train_test_split
+
+        data = load_iris()
+        X, y = data.data, data.target
+        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(X, y)
+
+    def test_with_lale_classifiers(self):
+        from lale.lib.sklearn import StackingClassifier
+
+        clf = StackingClassifier(estimators=[("base", LogisticRegression())])
+        trained = clf.fit(self.X_train, self.y_train)
+        trained.predict(self.X_test)
+
+    def test_with_lale_pipeline(self):
+        from lale.lib.sklearn import StackingClassifier
+
+        clf = StackingClassifier(estimators=[("base", PCA() >> LogisticRegression())])
+        trained = clf.fit(self.X_train, self.y_train)
+        trained.predict(self.X_test)
+
+    def test_with_hyperopt(self):
+        from lale.lib.lale import Hyperopt
+        from lale.lib.sklearn import StackingClassifier
+
+        clf = StackingClassifier(estimators=[("base", LogisticRegression())])
+        trained = clf.auto_configure(self.X_train, self.y_train, Hyperopt, max_evals=1)
+        print(trained.to_json())
+
+    def test_pipeline_with_hyperopt(self):
+        from lale.lib.lale import Hyperopt
+        from lale.lib.sklearn import StackingClassifier
+
+        clf = StackingClassifier(estimators=[("base", PCA() >> LogisticRegression())])
+        _ = clf.auto_configure(self.X_train, self.y_train, Hyperopt, max_evals=1)
+
+    def test_pipeline_choice_with_hyperopt(self):
+        from lale.lib.lale import Hyperopt
+        from lale.lib.sklearn import StackingClassifier
+
+        clf = StackingClassifier(
+            estimators=[
+                ("base", PCA() >> (LogisticRegression() | KNeighborsClassifier()))
+            ]
+        )
+        _ = clf.auto_configure(self.X_train, self.y_train, Hyperopt, max_evals=1)
+
+
 class TestSpuriousSideConstraintsClassification(unittest.TestCase):
     # This was prompted buy a bug, keeping it as it may help with support for other sklearn versions
     def setUp(self):

--- a/test/test_core_regressors.py
+++ b/test/test_core_regressors.py
@@ -46,7 +46,11 @@ def create_function_test_regressor(clf_name):
         module = importlib.import_module(module_name)
 
         class_ = getattr(module, class_name)
-        regr = class_()
+        regr = None
+        if class_name in ["StackingRegressor", "VotingRegressor"]:
+            regr = class_(estimators=[("base", SGDRegressor())])
+        else:
+            regr = class_()
 
         # test_schemas_are_schemas
         lale.type_checking.validate_is_schema(regr.input_schema_fit())
@@ -88,7 +92,8 @@ def create_function_test_regressor(clf_name):
 
 
 regressors = [
-    "lale.lib.sklearn.BaggingRegressor" "lale.lib.sklearn.DummyRegressor",
+    "lale.lib.sklearn.BaggingRegressor",
+    "lale.lib.sklearn.DummyRegressor",
     "lale.lib.sklearn.RandomForestRegressor",
     "lale.lib.sklearn.DecisionTreeRegressor",
     "lale.lib.sklearn.ExtraTreesRegressor",

--- a/test/test_core_regressors.py
+++ b/test/test_core_regressors.py
@@ -88,7 +88,7 @@ def create_function_test_regressor(clf_name):
 
 
 regressors = [
-    "lale.lib.sklearn.DummyRegressor",
+    "lale.lib.sklearn.BaggingRegressor" "lale.lib.sklearn.DummyRegressor",
     "lale.lib.sklearn.RandomForestRegressor",
     "lale.lib.sklearn.DecisionTreeRegressor",
     "lale.lib.sklearn.ExtraTreesRegressor",
@@ -102,6 +102,8 @@ regressors = [
     "lale.lib.sklearn.SVR",
     "lale.lib.sklearn.KNeighborsRegressor",
     "lale.lib.sklearn.LinearSVR",
+    "lale.lib.sklearn.StackingRegressor",
+    "lale.lib.sklearn.VotingRegressor",
 ]
 for clf in regressors:
     setattr(


### PR DESCRIPTION
Code here isn't necessarily final but the point of this pull request is to add and revise a few ensemble methods to make them compatible with Lale pipelines.

- Stacking: contributing `StackingClassifier` and `StackingRegressor` from scratch; overriding `_concatenate_predictions` 
to allow for pandas dataframe compatibility (sklearn by default converts to numpy arrays)
- Voting: contributing `VotingRegressor` from scratch and modifying `VotingClassifier` so that the latter has a `predict_proba` function (not exposed by default in sklearn but required by Lale post-mitigators)
- Bagging: contributing `BaggingRegressor` from scratch and modifying `BaggingClassifier` so that underlying estimators can receive pandas dataframes if provided (sklearn by default converts to numpy arrays)
- Tests added in `test_core_classifiers` and `test_core_regressors`