### PR TITLE
Adding set_docstrings() function calls for Stacking ensembles to generate docs

### DIFF
--- a/lale/lib/sklearn/stacking_classifier.py
+++ b/lale/lib/sklearn/stacking_classifier.py
@@ -268,3 +268,5 @@ StackingClassifier: lale.operators.PlannedIndividualOp
 StackingClassifier = lale.operators.make_operator(
     _StackingClassifierImpl, _combined_schemas
 )
+
+lale.docstrings.set_docstrings(StackingClassifier)

--- a/lale/lib/sklearn/stacking_regressor.py
+++ b/lale/lib/sklearn/stacking_regressor.py
@@ -246,3 +246,5 @@ StackingRegressor: lale.operators.PlannedIndividualOp
 StackingRegressor = lale.operators.make_operator(
     _StackingRegressorImpl, _combined_schemas
 )
+
+lale.docstrings.set_docstrings(StackingRegressor)


### PR DESCRIPTION
Title pretty much explains it all. In the [PR that contributed `StackingClassifier` and `StackingRegressor`](https://github.com/IBM/lale/pull/713), I forgot to add `lale.docstrings.set_docstrings()` calls to make sure readthedocs info gets generated. Should be fixed in this PR.