### PR TITLE
Cat imputer

### DIFF
--- a/lale/lib/autoai_libs/cat_encoder.py
+++ b/lale/lib/autoai_libs/cat_encoder.py
@@ -151,7 +151,7 @@ In the inverse transform, an unknown category will be denoted as None.""",
                 },
                 "sklearn_version_family": {
                     "description": "The sklearn version for backward compatibiity with versions 019 and 020dev. Currently unused.",
-                    "enum": ["20", "23", None],
+                    "enum": ["20", "21", "22", "23", "24", None],
                     "default": None,
                 },
                 "activate_flag": {

--- a/lale/lib/autoai_libs/cat_imputer.py
+++ b/lale/lib/autoai_libs/cat_imputer.py
@@ -89,7 +89,7 @@ _hyperparams_schema = {
                 },
                 "sklearn_version_family": {
                     "description": "The sklearn version for backward compatibiity with versions 019 and 020dev. Currently unused.",
-                    "enum": ["20", "23", None],
+                    "enum": ["20", "21", "22", "23", "24", None],
                     "default": None,
                 },
                 "activate_flag": {


### PR DESCRIPTION
Updating the `sklearn_version_family` of `lale.lib.autoai_libs.CatImputer` and `lale.lib.autoai_libs.CatEncoder` to allow all version families. As per the documentation of autoai_libs, this hyperparameter is ignored, so allowing more values to avoid errors.