### PR TITLE
Fixing Stacking bug related to concatenating dataframes with cross-validation

### DIFF
--- a/lale/lib/sklearn/stacking_utils.py
+++ b/lale/lib/sklearn/stacking_utils.py
@@ -25,6 +25,8 @@ def _concatenate_predictions_pandas(base_stacking, X, predictions):
                 f"estimator_{idx}_feature_{i}" for i in range(X_meta[-1].shape[1])
             ],
         )
+        if base_stacking.passthrough:
+            X_meta[-1].set_index(X.index, inplace=True)
         idx += 1
     if base_stacking.passthrough:
         X_meta.append(X)


### PR DESCRIPTION
The helper method `_concatenate_predictions_pandas` written for Stacking ensembles has a bug when cross-validation techniques are used to partition data and when `passthrough=True`. As the code exists now, the cross-validation data, let's say `X_cv`, retains indices from the original `X` dataframe (and can be any value in `[0, X.shape[0]]`), but the predictions generated by each base estimator have indices corresponding to `range(X_cv.shape[0])`.

The join that happens in `pd.concat()` is an outer join that results in a ton of nans that throw errors, let alone a conceptually incorrect dataframe. This PR addresses the issue by forcing the row index of each set of predictions to be equivalent to that used by `X_cv` provided `passthrough=True`.