### PR TITLE
Converting pd.Series to numpy array while concatenating predictions for Stacking

### DIFF
--- a/lale/lib/sklearn/stacking_utils.py
+++ b/lale/lib/sklearn/stacking_utils.py
@@ -7,7 +7,10 @@ def _concatenate_predictions_pandas(base_stacking, X, predictions):
     for est_idx, preds in enumerate(predictions):
         # case where the the estimator returned a 1D array
         if preds.ndim == 1:
-            X_meta.append(preds.reshape(-1, 1))
+            if isinstance(preds, pd.Series):
+                X_meta.append(preds.to_numpy().reshape(-1, 1))
+            else:
+                X_meta.append(preds.reshape(-1, 1))
         else:
             if (
                 base_stacking.stack_method_[est_idx] == "predict_proba"


### PR DESCRIPTION
Currently, if one of the base estimators produces predictions in the form of a pandas Series, it will crash because Series objects do not support `reshape()`. Converting to numpy array first to get around this issue.