### PR TITLE
predict_proba implementations for supported AIF360 algorithms

### DIFF
--- a/lale/lib/aif360/adversarial_debiasing.py
+++ b/lale/lib/aif360/adversarial_debiasing.py
@@ -27,7 +27,9 @@ import lale.operators
 from .util import (
     _BaseInEstimatorImpl,
     _categorical_fairness_properties,
+    _categorical_input_predict_proba_schema,
     _categorical_input_predict_schema,
+    _categorical_output_predict_proba_schema,
     _categorical_output_predict_schema,
     _categorical_supervised_input_fit_schema,
 )
@@ -84,6 +86,8 @@ or with
 _input_fit_schema = _categorical_supervised_input_fit_schema
 _input_predict_schema = _categorical_input_predict_schema
 _output_predict_schema = _categorical_output_predict_schema
+_input_predict_proba_schema = _categorical_input_predict_proba_schema
+_output_predict_proba_schema = _categorical_output_predict_proba_schema
 
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
@@ -210,6 +214,8 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 

--- a/lale/lib/aif360/calibrated_eq_odds_postprocessing.py
+++ b/lale/lib/aif360/calibrated_eq_odds_postprocessing.py
@@ -20,7 +20,9 @@ import lale.operators
 from .util import (
     _BasePostEstimatorImpl,
     _categorical_fairness_properties,
+    _categorical_input_predict_proba_schema,
     _categorical_input_predict_schema,
+    _categorical_output_predict_proba_schema,
     _categorical_output_predict_schema,
     _categorical_supervised_input_fit_schema,
 )
@@ -58,6 +60,8 @@ class _CalibratedEqOddsPostprocessingImpl(_BasePostEstimatorImpl):
 _input_fit_schema = _categorical_supervised_input_fit_schema
 _input_predict_schema = _categorical_input_predict_schema
 _output_predict_schema = _categorical_output_predict_schema
+_input_predict_proba_schema = _categorical_input_predict_proba_schema
+_output_predict_proba_schema = _categorical_output_predict_proba_schema
 
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
@@ -116,6 +120,8 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 

--- a/lale/lib/aif360/eq_odds_postprocessing.py
+++ b/lale/lib/aif360/eq_odds_postprocessing.py
@@ -52,6 +52,9 @@ class _EqOddsPostprocessingImpl(_BasePostEstimatorImpl):
             mitigator=mitigator,
         )
 
+    def predict_proba(self, X):
+        raise NotImplementedError()
+
 
 _input_fit_schema = _categorical_supervised_input_fit_schema
 _input_predict_schema = _categorical_input_predict_schema

--- a/lale/lib/aif360/gerry_fair_classifier.py
+++ b/lale/lib/aif360/gerry_fair_classifier.py
@@ -21,7 +21,9 @@ import lale.operators
 from .util import (
     _BaseInEstimatorImpl,
     _categorical_fairness_properties,
+    _categorical_input_predict_proba_schema,
     _categorical_input_predict_schema,
+    _categorical_output_predict_proba_schema,
     _categorical_output_predict_schema,
     _categorical_supervised_input_fit_schema,
 )
@@ -77,6 +79,8 @@ class _GerryFairClassifierImpl(_BaseInEstimatorImpl):
 _input_fit_schema = _categorical_supervised_input_fit_schema
 _input_predict_schema = _categorical_input_predict_schema
 _output_predict_schema = _categorical_output_predict_schema
+_input_predict_proba_schema = _categorical_input_predict_proba_schema
+_output_predict_proba_schema = _categorical_output_predict_proba_schema
 
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
@@ -201,6 +205,8 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 

--- a/lale/lib/aif360/meta_fair_classifier.py
+++ b/lale/lib/aif360/meta_fair_classifier.py
@@ -17,7 +17,12 @@ import aif360.algorithms.inprocessing
 import lale.docstrings
 import lale.operators
 
-from .util import _BaseInEstimatorImpl, _categorical_fairness_properties
+from .util import (
+    _BaseInEstimatorImpl,
+    _categorical_fairness_properties,
+    _categorical_input_predict_proba_schema,
+    _categorical_output_predict_proba_schema,
+)
 
 
 class _MetaFairClassifierImpl(_BaseInEstimatorImpl):
@@ -93,6 +98,9 @@ _output_predict_schema = {
     ],
 }
 
+_input_predict_proba_schema = _categorical_input_predict_proba_schema
+_output_predict_proba_schema = _categorical_output_predict_proba_schema
+
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
     "allOf": [
@@ -164,6 +172,8 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 

--- a/lale/lib/aif360/prejudice_remover.py
+++ b/lale/lib/aif360/prejudice_remover.py
@@ -20,7 +20,9 @@ import lale.operators
 from .util import (
     _BaseInEstimatorImpl,
     _categorical_fairness_properties,
+    _categorical_input_predict_proba_schema,
     _categorical_input_predict_schema,
+    _categorical_output_predict_proba_schema,
     _categorical_output_predict_schema,
     _categorical_supervised_input_fit_schema,
 )
@@ -49,6 +51,8 @@ class _PrejudiceRemoverImpl(_BaseInEstimatorImpl):
 _input_fit_schema = _categorical_supervised_input_fit_schema
 _input_predict_schema = _categorical_input_predict_schema
 _output_predict_schema = _categorical_output_predict_schema
+_input_predict_proba_schema = _categorical_input_predict_proba_schema
+_output_predict_proba_schema = _categorical_output_predict_proba_schema
 
 _hyperparams_schema = {
     "description": "Hyperparameter schema.",
@@ -108,6 +112,8 @@ _combined_schemas = {
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 

--- a/lale/lib/aif360/reject_option_classification.py
+++ b/lale/lib/aif360/reject_option_classification.py
@@ -64,6 +64,9 @@ class _RejectOptionClassificationImpl(_BasePostEstimatorImpl):
             mitigator=mitigator,
         )
 
+    def predict_proba(self, X):
+        raise NotImplementedError()
+
 
 _input_fit_schema = _categorical_supervised_input_fit_schema
 _input_predict_schema = _categorical_input_predict_schema

--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -867,6 +867,30 @@ _categorical_output_predict_schema = {
     ],
 }
 
+_categorical_input_predict_proba_schema = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["X"],
+    "properties": {
+        "X": {
+            "description": "Features; the outer array is over samples.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {"anyOf": [{"type": "number"}, {"type": "string"}]},
+            },
+        }
+    },
+}
+
+_categorical_output_predict_proba_schema = {
+    "description": "The class probabilities of the input samples",
+    "anyOf": [
+        {"type": "array", "items": {"laleType": "Any"}},
+        {"type": "array", "items": {"type": "array", "items": {"laleType": "Any"}}},
+    ],
+}
+
 _categorical_input_transform_schema = {
     "description": "Input data schema for transform.",
     "type": "object",


### PR DESCRIPTION
Adding `predict_proba` implementations by defining it on the base classes for in-estimator and post-estimator mitigators and raising errors or adding comments in cases where the function is not supported (currently `EqOddsPostprocessing`, `GerryFairClassifier`, and `RejectOptionClassification`).

Docstrings were updated as appropriate. No tests added because there is currently a lack of infrastructure around `predict` tests in general, plus some of these `predict_proba` functions are non-deterministic (as in the case of `CalibratedEqOdsPostprocessing`).