### PR TITLE
Making sure classes_ works for in-estimator and post-estimator mitigators

### DIFF
--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -712,7 +712,7 @@ class _BaseInEstimatorImpl:
         result_data = self.mitigator.predict(encoded_data)
         favorable_probs = result_data.scores
         all_probs = np.hstack([1 - favorable_probs, favorable_probs])
-        return pd.DataFrame(all_probs, columns=["0", "1"])
+        return all_probs
 
 
 class _BasePostEstimatorImpl:
@@ -799,7 +799,11 @@ class _BasePostEstimatorImpl:
         dataset_out = self.mitigator.predict(dataset_pred)
         favorable_probs = dataset_out.scores
         all_probs = np.hstack([1 - favorable_probs, favorable_probs])
-        return pd.DataFrame(all_probs, columns=["0", "1"])
+        return all_probs
+
+    @property
+    def classes_(self):
+        return self.estimator.classes_
 
 
 _categorical_supervised_input_fit_schema = {

--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -774,7 +774,9 @@ class _BasePostEstimatorImpl:
             encoded_X, predicted_y, predicted_probas
         )
         self.mitigator = self.mitigator.fit(dataset_true, dataset_pred)
-        self.unfavorable_labels = list(set(list(y)) - set(list(self.favorable_labels)))
+        self.classes_ = set(list(y))
+        self.unfavorable_labels = list(self.classes_ - set(list(self.favorable_labels)))
+        self.classes_ = np.array(list(self.classes_))
         return self
 
     def predict(self, X):

--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -696,7 +696,9 @@ class _BaseInEstimatorImpl:
         )
         encoded_data = self._prep_and_encode(X, y)
         self.mitigator.fit(encoded_data)
-        self.unfavorable_labels = list(set(list(y)) - set(list(self.favorable_labels)))
+        self.classes_ = set(list(y))
+        self.unfavorable_labels = list(self.classes_ - set(list(self.favorable_labels)))
+        self.classes_ = np.array(list(self.classes_))
         return self
 
     def predict(self, X):
@@ -800,10 +802,6 @@ class _BasePostEstimatorImpl:
         favorable_probs = dataset_out.scores
         all_probs = np.hstack([1 - favorable_probs, favorable_probs])
         return all_probs
-
-    @property
-    def classes_(self):
-        return self.estimator.classes_
 
 
 _categorical_supervised_input_fit_schema = {

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -499,6 +499,8 @@ class Operator(metaclass=AbstractVisitorMeta):
                     model = impl
                 elif hasattr(impl, "estimator"):
                     model = impl.estimator
+                elif hasattr(impl, "mitigator"):
+                    model = impl
 
         return "passthrough" if model is None else model
 
@@ -1365,6 +1367,8 @@ class IndividualOp(Operator):
                 self.impl.estimator, "classes_"
             ):
                 return self.impl.estimator.classes_
+            elif hasattr(self.impl, "classes_"):
+                return self.impl.classes_
 
         return super().__getattr__(name)
 

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -497,6 +497,9 @@ class Operator(metaclass=AbstractVisitorMeta):
                     model = impl._wrapped_model
                 elif isinstance(impl, sklearn.base.BaseEstimator):
                     model = impl
+                elif hasattr(impl, "estimator"):
+                    model = impl.estimator
+
         return "passthrough" if model is None else model
 
     @property
@@ -1357,6 +1360,11 @@ class IndividualOp(Operator):
                 return "classifier"  # satisfy sklearn.base.is_classifier(op)
             elif self.is_regressor():
                 return "regressor"  # satisfy sklearn.base.is_regressor(op)
+        if name == "classes_":
+            if hasattr(self.impl, "estimator") and hasattr(
+                self.impl.estimator, "classes_"
+            ):
+                return self.impl.estimator.classes_
 
         return super().__getattr__(name)
 

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -495,13 +495,8 @@ class Operator(metaclass=AbstractVisitorMeta):
                 impl = op._impl_instance()
                 if hasattr(impl, "_wrapped_model"):
                     model = impl._wrapped_model
-                elif isinstance(impl, sklearn.base.BaseEstimator):
+                else:
                     model = impl
-                elif hasattr(impl, "estimator"):
-                    model = impl.estimator
-                elif hasattr(impl, "mitigator"):
-                    model = impl
-
         return "passthrough" if model is None else model
 
     @property
@@ -1362,13 +1357,6 @@ class IndividualOp(Operator):
                 return "classifier"  # satisfy sklearn.base.is_classifier(op)
             elif self.is_regressor():
                 return "regressor"  # satisfy sklearn.base.is_regressor(op)
-        if name == "classes_":
-            if hasattr(self.impl, "estimator") and hasattr(
-                self.impl.estimator, "classes_"
-            ):
-                return self.impl.estimator.classes_
-            elif hasattr(self.impl, "classes_"):
-                return self.impl.classes_
 
         return super().__getattr__(name)
 

--- a/test/test_aif360_ensembles.py
+++ b/test/test_aif360_ensembles.py
@@ -1,0 +1,308 @@
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Any, Dict
+
+from lale.lib.aif360 import (
+    CalibratedEqOddsPostprocessing,
+    DisparateImpactRemover,
+    PrejudiceRemover,
+    fair_stratified_train_test_split,
+)
+from lale.lib.aif360.datasets import fetch_creditg_df
+from lale.lib.sklearn import (
+    AdaBoostClassifier,
+    BaggingClassifier,
+    DecisionTreeClassifier,
+    LogisticRegression,
+    StackingClassifier,
+    VotingClassifier,
+)
+
+
+class TestEnsemblesWithAIF360(unittest.TestCase):
+    train_X = None
+    train_y = None
+    test_X = None
+    fairness_info: Dict[str, Any] = {"temp": 0}
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        X, y, fi = fetch_creditg_df(preprocess=True)
+        train_X, test_X, train_y, _ = fair_stratified_train_test_split(X, y, **fi)
+        cls.train_X = train_X
+        cls.train_y = train_y
+        cls.test_X = test_X
+        cls.fairness_info = fi
+
+    @classmethod
+    def _attempt_fit_predict(cls, model):
+        trained = model.fit(cls.train_X, cls.train_y)
+        trained.predict(cls.test_X)
+
+    def test_bagging_pre_estimator_mitigation_ensemble(self):
+        model = DisparateImpactRemover(**self.fairness_info) >> BaggingClassifier(
+            base_estimator=DecisionTreeClassifier()
+        )
+        self._attempt_fit_predict(model)
+
+    def test_bagging_post_estimator_mitigation_ensemble(self):
+        model = CalibratedEqOddsPostprocessing(
+            **self.fairness_info,
+            estimator=BaggingClassifier(base_estimator=DecisionTreeClassifier())
+        )
+        self._attempt_fit_predict(model)
+
+    def test_bagging_pre_estimator_mitigation_base(self):
+        model = BaggingClassifier(
+            base_estimator=DisparateImpactRemover(**self.fairness_info)
+            >> DecisionTreeClassifier()
+        )
+        self._attempt_fit_predict(model)
+
+    def test_bagging_in_estimator_mitigation_base(self):
+        model = BaggingClassifier(base_estimator=PrejudiceRemover(**self.fairness_info))
+        self._attempt_fit_predict(model)
+
+    def test_bagging_post_estimator_mitigation_base(self):
+        model = BaggingClassifier(
+            base_estimator=CalibratedEqOddsPostprocessing(
+                **self.fairness_info, estimator=DecisionTreeClassifier()
+            )
+        )
+        self._attempt_fit_predict(model)
+
+    def test_adaboost_pre_estimator_mitigation_ensemble(self):
+        model = DisparateImpactRemover(**self.fairness_info) >> AdaBoostClassifier(
+            base_estimator=DecisionTreeClassifier()
+        )
+        self._attempt_fit_predict(model)
+
+    def test_adaboost_post_estimator_mitigation_ensemble(self):
+        model = CalibratedEqOddsPostprocessing(
+            **self.fairness_info,
+            estimator=AdaBoostClassifier(base_estimator=DecisionTreeClassifier())
+        )
+        self._attempt_fit_predict(model)
+
+    def test_adaboost_pre_estimator_mitigation_base(self):
+        model = AdaBoostClassifier(
+            base_estimator=DisparateImpactRemover(**self.fairness_info)
+            >> DecisionTreeClassifier()
+        )
+        self._attempt_fit_predict(model)
+
+    def test_adaboost_in_estimator_mitigation_base(self):
+        model = AdaBoostClassifier(
+            base_estimator=PrejudiceRemover(**self.fairness_info)
+        )
+        self._attempt_fit_predict(model)
+
+    def test_adaboost_post_estimator_mitigation_base(self):
+        model = AdaBoostClassifier(
+            base_estimator=CalibratedEqOddsPostprocessing(
+                **self.fairness_info, estimator=DecisionTreeClassifier()
+            )
+        )
+        self._attempt_fit_predict(model)
+
+    def test_voting_pre_estimator_mitigation_ensemble(self):
+        model = DisparateImpactRemover(**self.fairness_info) >> VotingClassifier(
+            estimators=[("dtc", DecisionTreeClassifier()), ("lr", LogisticRegression())]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_voting_post_estimator_mitigation_ensemble(self):
+        model = CalibratedEqOddsPostprocessing(
+            **self.fairness_info,
+            estimator=VotingClassifier(
+                estimators=[
+                    ("dtc", DecisionTreeClassifier()),
+                    ("lr", LogisticRegression()),
+                ]
+            )
+        )
+        self._attempt_fit_predict(model)
+
+    def test_voting_pre_estimator_mitigation_base(self):
+        model = VotingClassifier(
+            estimators=[
+                (
+                    "dir+dtc",
+                    DisparateImpactRemover(**self.fairness_info)
+                    >> DecisionTreeClassifier(),
+                ),
+                ("lr", LogisticRegression()),
+            ]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_voting_in_estimator_mitigation_base(self):
+        model = VotingClassifier(
+            estimators=[
+                ("pr", PrejudiceRemover(**self.fairness_info)),
+                ("lr", LogisticRegression()),
+            ]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_voting_post_estimator_mitigation_base(self):
+        model = VotingClassifier(
+            estimators=[
+                (
+                    "dtc+ceop",
+                    CalibratedEqOddsPostprocessing(
+                        **self.fairness_info, estimator=DecisionTreeClassifier()
+                    ),
+                ),
+                ("lr", LogisticRegression()),
+            ]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_pre_estimator_mitigation_ensemble(self):
+        model = DisparateImpactRemover(**self.fairness_info) >> StackingClassifier(
+            estimators=[("dtc", DecisionTreeClassifier()), ("lr", LogisticRegression())]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_post_estimator_mitigation_ensemble(self):
+        model = CalibratedEqOddsPostprocessing(
+            **self.fairness_info,
+            estimator=StackingClassifier(
+                estimators=[
+                    ("dtc", DecisionTreeClassifier()),
+                    ("lr", LogisticRegression()),
+                ]
+            )
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_pre_estimator_mitigation_base_only(self):
+        model = StackingClassifier(
+            estimators=[
+                (
+                    "dir+dtc",
+                    DisparateImpactRemover(**self.fairness_info)
+                    >> DecisionTreeClassifier(),
+                ),
+                ("lr", LogisticRegression()),
+            ]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_pre_estimator_mitigation_base_and_final(self):
+        model = StackingClassifier(
+            estimators=[
+                (
+                    "dir+dtc",
+                    DisparateImpactRemover(**self.fairness_info)
+                    >> DecisionTreeClassifier(),
+                ),
+                ("lr", LogisticRegression()),
+            ],
+            final_estimator=DisparateImpactRemover(**self.fairness_info)
+            >> DecisionTreeClassifier(),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_pre_estimator_mitigation_final_only(self):
+        model = StackingClassifier(
+            estimators=[
+                ("dtc", DecisionTreeClassifier()),
+                ("lr", LogisticRegression()),
+            ],
+            final_estimator=DisparateImpactRemover(**self.fairness_info)
+            >> DecisionTreeClassifier(),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_in_estimator_mitigation_base_only(self):
+        model = StackingClassifier(
+            estimators=[
+                ("pr", PrejudiceRemover(**self.fairness_info)),
+                ("lr", LogisticRegression()),
+            ]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_in_estimator_mitigation_base_and_final(self):
+        model = StackingClassifier(
+            estimators=[
+                ("pr", PrejudiceRemover(**self.fairness_info)),
+                ("lr", LogisticRegression()),
+            ],
+            final_estimator=PrejudiceRemover(**self.fairness_info),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_in_estimator_mitigation_final_only(self):
+        model = StackingClassifier(
+            estimators=[
+                ("dtc", DecisionTreeClassifier()),
+                ("lr", LogisticRegression()),
+            ],
+            final_estimator=PrejudiceRemover(**self.fairness_info),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_post_estimator_mitigation_base_only(self):
+        model = StackingClassifier(
+            estimators=[
+                (
+                    "dtc+ceop",
+                    CalibratedEqOddsPostprocessing(
+                        **self.fairness_info, estimator=DecisionTreeClassifier()
+                    ),
+                ),
+                ("lr", LogisticRegression()),
+            ]
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_post_estimator_mitigation_base_and_final(self):
+        model = StackingClassifier(
+            estimators=[
+                (
+                    "dtc+ceop",
+                    CalibratedEqOddsPostprocessing(
+                        **self.fairness_info, estimator=DecisionTreeClassifier()
+                    ),
+                ),
+                ("lr", LogisticRegression()),
+            ],
+            final_estimator=CalibratedEqOddsPostprocessing(
+                **self.fairness_info, estimator=DecisionTreeClassifier()
+            ),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_post_estimator_mitigation_final_only(self):
+        model = StackingClassifier(
+            estimators=[
+                ("dtc", DecisionTreeClassifier()),
+                ("lr", LogisticRegression()),
+            ],
+            final_estimator=CalibratedEqOddsPostprocessing(
+                **self.fairness_info, estimator=DecisionTreeClassifier()
+            ),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)


### PR DESCRIPTION
In order to use in-estimator mitigators like `PrejudiceRemover` and post-estimator mitigators like `CalibratedEqOddsPostprocessing` as part of Bagging and Boosting ensembles, the base estimator implementations require the `classes_` attribute on top of a `predict_proba` definition. [A prior PR](https://github.com/IBM/lale/pull/743) implemented `predict_proba`; this one handles the `classes_` attribute.