### PR TITLE
Adding _estimator_type to XGBClassifier and XGBRegressor

### DIFF
--- a/lale/lib/xgboost/xgb_classifier.py
+++ b/lale/lib/xgboost/xgb_classifier.py
@@ -59,6 +59,7 @@ class _XGBClassifierImpl:
     def __init__(self, **hyperparams):
         self.validate_hyperparams(**hyperparams)
         self._hyperparams = hyperparams
+        self._estimator_type = "classifier"
 
     def fit(self, X, y, **fit_params):
         result = _XGBClassifierImpl(**self._hyperparams)

--- a/lale/lib/xgboost/xgb_regressor.py
+++ b/lale/lib/xgboost/xgb_regressor.py
@@ -59,6 +59,7 @@ class _XGBRegressorImpl:
     def __init__(self, **hyperparams):
         self.validate_hyperparams(**hyperparams)
         self._hyperparams = hyperparams
+        self._estimator_type = "regressor"
 
     def fit(self, X, y, **fit_params):
         result = _XGBRegressorImpl(**self._hyperparams)

--- a/test/test_aif360_ensembles.py
+++ b/test/test_aif360_ensembles.py
@@ -30,6 +30,7 @@ from lale.lib.sklearn import (
     StackingClassifier,
     VotingClassifier,
 )
+from lale.lib.xgboost import XGBClassifier
 
 
 class TestEnsemblesWithAIF360(unittest.TestCase):
@@ -227,6 +228,18 @@ class TestEnsemblesWithAIF360(unittest.TestCase):
             ],
             final_estimator=DisparateImpactRemover(**self.fairness_info)
             >> DecisionTreeClassifier(),
+            passthrough=True,
+        )
+        self._attempt_fit_predict(model)
+
+    def test_stacking_pre_estimator_mitigation_final_only_xgboost(self):
+        model = StackingClassifier(
+            estimators=[
+                ("dtc", DecisionTreeClassifier()),
+                ("xgb", XGBClassifier(use_label_encoder=False, verbosity=0)),
+            ],
+            final_estimator=DisparateImpactRemover(**self.fairness_info)
+            >> XGBClassifier(use_label_encoder=False, verbosity=0),
             passthrough=True,
         )
         self._attempt_fit_predict(model)


### PR DESCRIPTION
In order to use a classifier as a `final_estimator` in a `StackingClassifier`, the `_estimator_type` of that classifier must be defined and have a value of `"classifier"`. `DecisionTreeClassifier` is configured properly by default since it comes from `sklearn`, but `XGBClassifier` (which we're trying to use in experiments going forward) does _not_ have this property. `"regressor"` is also currently missing from `XGBRegressor`. 

This PR fixes these issues and updates the AIF360 ensembles test suite (since this was only an issue when pre-estimator mitigation was applied) with a test case that should catch this problem.