### PR TITLE
Fixing a mistake in the second schema constraint for LightGBM.

### DIFF
--- a/lale/lib/lightgbm/lgbm_classifier.py
+++ b/lale/lib/lightgbm/lgbm_classifier.py
@@ -128,11 +128,26 @@ _hyperparams_schema = {
             "properties": {
                 "boosting_type": {
                     "anyOf": [
-                        {"enum": ["gbdt", "dart"]},
-                        {"enum": ["goss", "rf"], "forOptimizer": False},
+                        {
+                            "enum": ["gbdt"],
+                            "description": "Traditional Gradient Boosting Decision Tree.",
+                        },
+                        {
+                            "enum": ["dart"],
+                            "description": "Dropouts meet Multiple Additive Regression Trees.",
+                        },
+                        {
+                            "enum": ["goss"],
+                            "forOptimizer": False,
+                            "description": "Gradient-based One-Side Sampling.",
+                        },
+                        {
+                            "enum": ["rf"],
+                            "forOptimizer": False,
+                            "description": "Random Forest.",
+                        },
                     ],
                     "default": "gbdt",
-                    "description": "‘gbdt’, traditional Gradient Boosting Decision Tree. ‘dart’, Dropouts meet Multiple Additive Regression Trees. ‘goss’, Gradient-based One-Side Sampling. ‘rf’, Random Forest.",
                 },
                 "num_leaves": {
                     "anyOf": [
@@ -295,23 +310,19 @@ _hyperparams_schema = {
             ],
         },
         {
-            "description": "boosting_type `goss` can not use bagging (which means subsample_freq = 0 and subsample = 1.0)",
+            "description": "boosting_type `goss` cannot use bagging (which means subsample_freq = 0 and subsample = 1.0)",
             "anyOf": [
                 {
                     "type": "object",
                     "properties": {"boosting_type": {"not": {"enum": ["goss"]}}},
                 },
                 {
-                    "allOf": [
-                        {
-                            "type": "object",
-                            "properties": {"subsample_freq": {"enum": [0]}},
-                        },
-                        {
-                            "type": "object",
-                            "properties": {"subsample": {"enum": [1.0]}},
-                        },
-                    ]
+                    "type": "object",
+                    "properties": {"subsample_freq": {"enum": [0]}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"subsample": {"enum": [1.0]}},
                 },
             ],
         },

--- a/lale/lib/lightgbm/lgbm_regressor.py
+++ b/lale/lib/lightgbm/lgbm_regressor.py
@@ -117,11 +117,26 @@ _hyperparams_schema = {
             "properties": {
                 "boosting_type": {
                     "anyOf": [
-                        {"enum": ["gbdt", "dart"]},
-                        {"enum": ["goss", "rf"], "forOptimizer": False},
+                        {
+                            "enum": ["gbdt"],
+                            "description": "Traditional Gradient Boosting Decision Tree.",
+                        },
+                        {
+                            "enum": ["dart"],
+                            "description": "Dropouts meet Multiple Additive Regression Trees.",
+                        },
+                        {
+                            "enum": ["goss"],
+                            "forOptimizer": False,
+                            "description": "Gradient-based One-Side Sampling.",
+                        },
+                        {
+                            "enum": ["rf"],
+                            "forOptimizer": False,
+                            "description": "Random Forest.",
+                        },
                     ],
                     "default": "gbdt",
-                    "description": "‘gbdt’, traditional Gradient Boosting Decision Tree. ‘dart’, Dropouts meet Multiple Additive Regression Trees. ‘goss’, Gradient-based One-Side Sampling. ‘rf’, Random Forest.",
                 },
                 "num_leaves": {
                     "anyOf": [
@@ -255,7 +270,45 @@ _hyperparams_schema = {
                     "description": "The type of feature importance to be filled into `feature_importances_`.",
                 },
             },
-        }
+        },
+        {
+            "description": "boosting_type `rf` needs bagging (which means subsample_freq > 0 and subsample < 1.0)",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"boosting_type": {"not": {"enum": ["rf"]}}},
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {"subsample_freq": {"not": {"enum": [0]}}},
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"subsample": {"not": {"enum": [1.0]}}},
+                        },
+                    ]
+                },
+            ],
+        },
+        {
+            "description": "boosting_type `goss` cannot use bagging (which means subsample_freq = 0 and subsample = 1.0)",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"boosting_type": {"not": {"enum": ["goss"]}}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"subsample_freq": {"enum": [0]}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"subsample": {"enum": [1.0]}},
+                },
+            ],
+        },
     ],
 }
 


### PR DESCRIPTION
A collaborator carefully inspected the code and found that the constraint about `boosting_type,subsample_freq,subsample` was wrong. LightGBM checks this constraint in C++ code with a conjunction (`&&`), so after negation and push-down, that becomes a JSON Schema disjunction (`anyOf`). Besides fixing that mistake, this PR also includes a couple of other cleanups. One is to add the same constraints to `LGBMRegressor`; previously they were only in `LGBMCLassifier`. The other is to shred the documentation of `boosting_type` into the separate enum constants so the automatically generated documentation on readthedocs looks a little nicer.