### PR TITLE
Improvements to error messages and documentation.

### DIFF
--- a/examples/demo_help_and_errors.ipynb
+++ b/examples/demo_help_and_errors.ipynb
@@ -51,7 +51,7 @@
       "    \"minimumForOptimizer\": 0.03125,\n",
       "    \"maximumForOptimizer\": 32768,\n",
       "}\n",
-      "Value: 0.0\n"
+      "Invalid value: 0.0\n"
      ]
     }
    ],
@@ -87,8 +87,8 @@
       "Invalid configuration for LR(solver='sag', penalty='l1') due to constraint the newton-cg, sag, and lbfgs solvers support only l2 or no penalties.\n",
       "Some possible fixes include:\n",
       "- set penalty='l2'\n",
-      "Schema of constraint 1: https://lale.readthedocs.io/en/latest/modules/lale.lib.sklearn.logistic_regression.html#constraint-1\n",
-      "Value: {'solver': 'sag', 'penalty': 'l1', 'dual': False, 'C': 1.0, 'tol': 0.0001, 'fit_intercept': True, 'intercept_scaling': 1.0, 'class_weight': None, 'random_state': None, 'max_iter': 100, 'multi_class': 'auto', 'verbose': 0, 'warm_start': False, 'n_jobs': None, 'l1_ratio': None}\n"
+      "Schema of failing constraint: https://lale.readthedocs.io/en/latest/modules/lale.lib.sklearn.logistic_regression.html#constraint-1\n",
+      "Invalid value: {'solver': 'sag', 'penalty': 'l1', 'dual': False, 'C': 1.0, 'tol': 0.0001, 'fit_intercept': True, 'intercept_scaling': 1.0, 'class_weight': None, 'random_state': None, 'max_iter': 100, 'multi_class': 'auto', 'verbose': 0, 'warm_start': False, 'n_jobs': None, 'l1_ratio': None}\n"
      ]
     }
    ],
@@ -120,8 +120,8 @@
       "Invalid configuration for LR(penalty='l2', solver='sag', dual=True) due to constraint the dual formulation is only implemented for l2 penalty with the liblinear solver.\n",
       "Some possible fixes include:\n",
       "- set dual=False\n",
-      "Schema of constraint 2: https://lale.readthedocs.io/en/latest/modules/lale.lib.sklearn.logistic_regression.html#constraint-2\n",
-      "Value: {'penalty': 'l2', 'solver': 'sag', 'dual': True, 'C': 1.0, 'tol': 0.0001, 'fit_intercept': True, 'intercept_scaling': 1.0, 'class_weight': None, 'random_state': None, 'max_iter': 100, 'multi_class': 'auto', 'verbose': 0, 'warm_start': False, 'n_jobs': None, 'l1_ratio': None}\n"
+      "Schema of failing constraint: https://lale.readthedocs.io/en/latest/modules/lale.lib.sklearn.logistic_regression.html#constraint-2\n",
+      "Invalid value: {'penalty': 'l2', 'solver': 'sag', 'dual': True, 'C': 1.0, 'tol': 0.0001, 'fit_intercept': True, 'intercept_scaling': 1.0, 'class_weight': None, 'random_state': None, 'max_iter': 100, 'multi_class': 'auto', 'verbose': 0, 'warm_start': False, 'n_jobs': None, 'l1_ratio': None}\n"
      ]
     }
    ],

--- a/lale/lib/sklearn/dummy_classifier.py
+++ b/lale/lib/sklearn/dummy_classifier.py
@@ -34,18 +34,29 @@ _hyperparams_schema = {
             ],
             "properties": {
                 "strategy": {
-                    "description": """Strategy to use to generate predictions.
-- “stratified”: generates predictions by respecting the training set’s class distribution.
-- “most_frequent”: always predicts the most frequent label in the training set.
-- “prior”: always predicts the class that maximizes the class prior (like “most_frequent”) and predict_proba returns the class prior.
-- “uniform”: generates predictions uniformly at random.
-- “constant”: always predicts a constant label that is provided by the user. This is useful for metrics that evaluate a non-majority class""",
-                    "enum": [
-                        "stratified",
-                        "most_frequent",
-                        "prior",
-                        "uniform",
-                        "constant",
+                    "description": "Strategy to use to generate predictions.",
+                    "anyOf": [
+                        {
+                            "enum": ["stratified"],
+                            "description": "Generates predictions by respecting the training set's class distribution.",
+                        },
+                        {
+                            "enum": ["most_frequent"],
+                            "description": "Always predicts the most frequent label in the training set.",
+                        },
+                        {
+                            "enum": ["prior"],
+                            "description": "Always predicts the class that maximizes the class prior (like 'most_frequent') and predict_proba returns the class prior.",
+                        },
+                        {
+                            "enum": ["uniform"],
+                            "description": "Generates predictions uniformly at random.",
+                        },
+                        {
+                            "enum": ["constant"],
+                            "description": "Always predicts a constant label that is provided by the user. This is useful for metrics that evaluate a non-majority class",
+                            "forOptimizer": False,
+                        },
                     ],
                     "default": "prior",
                 },
@@ -73,6 +84,19 @@ _hyperparams_schema = {
                     "default": None,
                 },
             },
+        },
+        {
+            "description": "The constant strategy requires a non-None value for the constant hyperparameter.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"strategy": {"not": {"enum": ["constant"]}}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"constant": {"not": {"enum": [None]}}},
+                },
+            ],
         },
     ]
 }

--- a/lale/lib/sklearn/dummy_regressor.py
+++ b/lale/lib/sklearn/dummy_regressor.py
@@ -29,12 +29,27 @@ _hyperparams_schema = {
             "required": ["strategy", "quantile"],
             "properties": {
                 "strategy": {
-                    "description": """Strategy to use to generate predictions.
-- “mean”: always predicts the mean of the training set
-- “median”: always predicts the median of the training set
-- “quantile”: always predicts a specified quantile of the training set, provided with the quantile parameter.
-- “constant”: always predicts a constant value that is provided by the user.""",
-                    "enum": ["mean", "median", "quantile", "constant"],
+                    "description": "Strategy to use to generate predictions.",
+                    "anyOf": [
+                        {
+                            "enum": ["mean"],
+                            "description": "Always predicts the mean of the training set.",
+                        },
+                        {
+                            "enum": ["median"],
+                            "description": "Always predicts the median of the training set.",
+                        },
+                        {
+                            "enum": ["quantile"],
+                            "description": "Always predicts a specified quantile of the training set, provided with the quantile parameter.",
+                            "forOptimizer": False,
+                        },
+                        {
+                            "enum": ["constant"],
+                            "description": "Always predicts a constant label that is provided by the user. This is useful for metrics that evaluate a non-majority class",
+                            "forOptimizer": False,
+                        },
+                    ],
                     "default": "mean",
                 },
                 "constant": {
@@ -54,7 +69,33 @@ _hyperparams_schema = {
                     "default": None,
                 },
             },
-        }
+        },
+        {
+            "description": "The constant strategy requires a non-None value for the constant hyperparameter.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"strategy": {"not": {"enum": ["constant"]}}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"constant": {"not": {"enum": [None]}}},
+                },
+            ],
+        },
+        {
+            "description": "The quantile strategy requires a non-None value for the quantile hyperparameter.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"strategy": {"not": {"enum": ["quantile"]}}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"quantile": {"not": {"enum": [None]}}},
+                },
+            ],
+        },
     ]
 }
 

--- a/lale/lib/sklearn/logistic_regression.py
+++ b/lale/lib/sklearn/logistic_regression.py
@@ -168,14 +168,12 @@ preprocess the data with a scaler from sklearn.preprocessing.""",
                     "default": "l2",
                 },
                 "dual": {
-                    "description": """Dual or primal formulation.
-Dual formulation is only implemented for l2 penalty with liblinear solver. Prefer dual=False when n_samples > n_features.""",
+                    "description": "Dual or primal formulation. Prefer dual=False when n_samples > n_features.",
                     "type": "boolean",
                     "default": False,
                 },
                 "C": {
-                    "description": "Inverse regularization strength. Smaller values specify "
-                    "stronger regularization.",
+                    "description": "Inverse regularization strength. Smaller values specify stronger regularization.",
                     "type": "number",
                     "distribution": "loguniform",
                     "minimum": 0.0,
@@ -195,8 +193,7 @@ Dual formulation is only implemented for l2 penalty with liblinear solver. Prefe
                     "maximumForOptimizer": 0.01,
                 },
                 "fit_intercept": {
-                    "description": "Specifies whether a constant (bias or intercept) should be "
-                    "added to the decision function.",
+                    "description": "Specifies whether a constant (bias or intercept) should be added to the decision function.",
                     "type": "boolean",
                     "default": True,
                 },

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -1975,7 +1975,7 @@ class IndividualOp(Operator):
                 if descr.endswith("."):
                     descr = descr[:-1]
                 reason = f"constraint {descr[0].lower()}{descr[1:]}"
-                schema_path = f"constraint {e.schema_path[1]}"
+                schema_path = "failing constraint"
                 if self.documentation_url() is not None:
                     schema = f"{self.documentation_url()}#constraint-{e.schema_path[1]}"
             else:
@@ -1987,7 +1987,7 @@ class IndividualOp(Operator):
                 + f"due to {reason}.\n"
                 + proposed_fix
                 + f"Schema of {schema_path}: {schema}\n"
-                + f"Value: {e.instance}"
+                + f"Invalid value: {e.instance}"
             )
             raise jsonschema.ValidationError(msg)
         user_validator = getattr(class_, "validate_hyperparams", None)


### PR DESCRIPTION
- Minor wording tweaks in schema error messages to be more understandable.
- Fixed mistake in docstrings for unions, which should only prepend "or" at the top-level items.
- Added "and" in docstrings for top-level items of intersections.
- Added missing schema constraints to DummyClassifier and DummyRegressor.
- Split the documentation for the strategy of DummyClassifier and DummyRegressor so each enum constant can have its own description attached, and to exclude some constants from the optimizer.