### PR TITLE
Several modifications to new(er) datasets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,7 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager .[full,test]
     - name: Install deps for test_autoai_ts_libs
       run: pip install --upgrade --upgrade-strategy eager 'autoai-ts-libs'
-      with:
-        python-version: [3.7, 3.8]
+      python-version: [3.7, 3.8]
     - name: pre-commit checks
       uses: pre-commit/action@v2.0.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager .[full,test]
     - name: Install deps for test_autoai_ts_libs
       run: pip install --upgrade --upgrade-strategy eager 'autoai-ts-libs'
+      with:
+        python-version: [3.7, 3.8]
     - name: pre-commit checks
       uses: pre-commit/action@v2.0.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
       run: pip install -U numpy==1.19.2
     - name: Install dependencies
       run: pip install --upgrade --upgrade-strategy eager .[full,test]
-    # - name: Install deps for test_autoai_ts_libs
-    #   run: pip install --upgrade --upgrade-strategy eager 'autoai-ts-libs'
+    - name: Install deps for test_autoai_ts_libs
+      run: pip install --upgrade --upgrade-strategy eager 'autoai-ts-libs'
     - name: pre-commit checks
       uses: pre-commit/action@v2.0.0
 
@@ -103,9 +103,9 @@ jobs:
         - test-case: test/test_lale_lib_versions.py
           python-version: 3.7
           setup-target: '.[full,test]'
-        # - test-case: test/test_aif360.py
-        #   python-version: 3.7
-        #   setup-target: '.[full,test]'
+        - test-case: test/test_aif360.py
+          python-version: 3.7
+          setup-target: '.[full,test]'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Install dependencies
       run: pip install --upgrade --upgrade-strategy eager .[full,test]
     - name: Install deps for test_autoai_ts_libs
+      if: ${{ matrix.python-version == 3.7 }}
       run: pip install --upgrade --upgrade-strategy eager 'autoai-ts-libs'
-      python-version: [3.7, 3.8]
     - name: pre-commit checks
       uses: pre-commit/action@v2.0.0
 

--- a/lale/lib/aif360/__init__.py
+++ b/lale/lib/aif360/__init__.py
@@ -76,7 +76,6 @@ Datasets:
 ================
 * `fetch_adult_df`_
 * `fetch_bank_df`_
-* `fetch_boston_housing_df`_
 * `fetch_compas_df`_
 * `fetch_compas_violent_df`_
 * `fetch_creditg_df`_
@@ -164,7 +163,6 @@ zero or one to simplify the task for the mitigator.
 .. _`fetch_creditg_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_creditg_df
 .. _`fetch_ricci_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_ricci_df
 .. _`fetch_speeddating_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_speeddating_df
-.. _`fetch_boston_housing_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_boston_housing_df
 .. _`fetch_nursery_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_nursery_df
 .. _`fetch_titanic_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_titanic_df
 .. _`fetch_meps_panel19_fy2015_df`: lale.lib.aif360.datasets.html#lale.lib.aif360.datasets.fetch_meps_panel19_fy2015_df
@@ -180,9 +178,9 @@ zero or one to simplify the task for the mitigator.
 from .adversarial_debiasing import AdversarialDebiasing
 from .calibrated_eq_odds_postprocessing import CalibratedEqOddsPostprocessing
 from .datasets import (
+    _fetch_boston_housing_df,
     fetch_adult_df,
     fetch_bank_df,
-    fetch_boston_housing_df,
     fetch_compas_df,
     fetch_compas_violent_df,
     fetch_creditg_df,

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -847,7 +847,6 @@ def fetch_speeddating_df(preprocess=False):
       If True,
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
       encode labels in y as 0 or 1 to indicate favorable outcomes;
-      standardize numeric columns;
       and apply one-hot encoding to any remaining features in X that
       are categorical and not protected attributes.
 
@@ -908,11 +907,6 @@ def fetch_speeddating_df(preprocess=False):
         # drop wave column
         columns_to_drop.append("wave")
         dropped_X = orig_X.drop(labels=columns_to_drop, axis=1)
-        columns_to_standardize = dropped_X.columns[np.max(dropped_X) != 1]
-        for col in columns_to_standardize:
-            dropped_X[col] = (dropped_X[col] - np.mean(dropped_X[col])) / np.std(
-                dropped_X[col]
-            )
         encoded_X = dropped_X.assign(
             samerace=samerace, importance_same_race=importance_same_race
         )
@@ -1095,7 +1089,6 @@ def fetch_titanic_df(preprocess=False):
 
       If True,
       encode protected attributes in X as 0 or 1 to indicate privileged groups;
-      standardize numeric columns;
       and apply one-hot encoding to any remaining features in X that
       are categorical and not protected attributes.
 
@@ -1140,12 +1133,6 @@ def fetch_titanic_df(preprocess=False):
             list(filter(extra_categorical_columns_filter, orig_X.columns))
         )
         dropped_X = orig_X.drop(labels=columns_to_drop, axis=1)
-
-        columns_to_standardize = ["fare", "body"]
-        for col in columns_to_standardize:
-            dropped_X[col] = (dropped_X[col] - np.mean(dropped_X[col])) / np.std(
-                dropped_X[col]
-            )
         encoded_X = dropped_X.assign(sex=sex, age=age)
         fairness_info = {
             "favorable_labels": [1],

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -920,7 +920,7 @@ def fetch_speeddating_df(preprocess=False):
         return orig_X, orig_y, fairness_info
 
 
-def fetch_boston_housing_df(preprocess=False):
+def _fetch_boston_housing_df(preprocess=False):
     """
     Fetch the `Boston housing`_ dataset from sklearn and add `fairness info`.
 
@@ -930,7 +930,10 @@ def fetch_boston_housing_df(preprocess=False):
     1000(Bk - 0.63)^2 where Bk is the proportion of Blacks by town, and the disparate
     impact is 0.5. The data includes only numeric columns, with no missing values.
 
+    Hiding dataset from public consumption based on issues described at length `here`_
+
     .. _`Boston housing`: https://scikit-learn.org/0.20/datasets/index.html#boston-house-prices-dataset
+    .. _`here`: https://medium.com/@docintangible/racist-data-destruction-113e3eff54a8
 
     Parameters
     ----------

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -218,9 +218,9 @@ def fetch_tae_df(preprocess=False):
     at the University of Wisconsin--Madison.
     The prediction task is a classification on the type
     of rating a TA receives (1=Low, 2=Medium, 3=High). Without preprocessing,
-    the dataset has 151 rows and 5 columns. There are two protected
-    attributes, "summer_or_regular_semester" and "whether_of_not_the_ta_is_a_native_english_speaker" [sic],
-    and the disparate impact of 0.5. The data
+    the dataset has 151 rows and 5 columns. There is one protected
+    attributes, "whether_of_not_the_ta_is_a_native_english_speaker" [sic],
+    and the disparate impact of 0.45. The data
     includes both categorical and numeric columns, with no missing
     values.
 
@@ -231,8 +231,8 @@ def fetch_tae_df(preprocess=False):
     preprocess : boolean, optional, default False
 
       If True,
-      encode protected attributes in X as 0 or 1 to indicate privileged groups
-      ("native_english_speaker" and "summer" respectively);
+      encode protected attributes in X as 0 or 1 to indicate privileged group
+      ("native_english_speaker");
       encode labels in y as 0 or 1 to indicate favorable outcomes;
       and apply one-hot encoding to any remaining features in X that
       are categorical and not protecteded attributes.
@@ -265,27 +265,19 @@ def fetch_tae_df(preprocess=False):
             orig_X["whether_of_not_the_ta_is_a_native_english_speaker_1"] == 1,
             dtype=np.float64,
         )
-        summer = pd.Series(
-            orig_X["summer_or_regular_semester_1"] == 1, dtype=np.float64
-        )
         dropped_X = orig_X.drop(
             labels=[
                 "whether_of_not_the_ta_is_a_native_english_speaker_1",
                 "whether_of_not_the_ta_is_a_native_english_speaker_2",
-                "summer_or_regular_semester_1",
-                "summer_or_regular_semester_2",
             ],
             axis=1,
         )
-        encoded_X = dropped_X.assign(
-            native_english_speaker=native_english_speaker, summer=summer
-        )
+        encoded_X = dropped_X.assign(native_english_speaker=native_english_speaker)
         encoded_y = pd.Series(orig_y == 2, dtype=np.float64)
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [
                 {"feature": "native_english_speaker", "reference_group": [1]},
-                {"feature": "summer", "reference_group": [1]},
             ],
         }
         return encoded_X, encoded_y, fairness_info
@@ -297,7 +289,6 @@ def fetch_tae_df(preprocess=False):
                     "feature": "whether_of_not_the_ta_is_a_native_english_speaker",
                     "reference_group": [1],
                 },
-                {"feature": "summer_or_regular_semester", "reference_group": [1]},
             ],
         }
         return orig_X, orig_y, fairness_info

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -97,19 +97,19 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_compas_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 6_172, 51, {0, 1}, 0.589)
+        self._attempt_dataset(X, y, fairness_info, 6_172, 51, {0, 1}, 0.747)
 
     def test_dataset_compas_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 6_167, 401, {0, 1}, 0.591)
+        self._attempt_dataset(X, y, fairness_info, 5_278, 10, {0, 1}, 0.687)
 
     def test_dataset_compas_violent_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_violent_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 4_020, 51, {0, 1}, 0.772)
+        self._attempt_dataset(X, y, fairness_info, 4_020, 51, {0, 1}, 0.852)
 
     def test_dataset_compas_violent_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_compas_violent_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 4_015, 327, {0, 1}, 0.772)
+        self._attempt_dataset(X, y, fairness_info, 3_377, 10, {0, 1}, 0.822)
 
     def test_dataset_creditg_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_creditg_df(preprocess=False)

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -173,11 +173,11 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_tae_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_tae_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 151, 5, {1, 2, 3}, 0.347)
+        self._attempt_dataset(X, y, fairness_info, 151, 5, {1, 2, 3}, 0.449)
 
     def test_dataset_tae_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_tae_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 151, 5, {0, 1}, 0.347)
+        self._attempt_dataset(X, y, fairness_info, 151, 6, {0, 1}, 0.449)
 
     @classmethod
     def _try_download_csv(cls, filename):

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -154,12 +154,12 @@ class TestAIF360Datasets(unittest.TestCase):
         self._attempt_dataset(X, y, fairness_info, 8_378, 70, {0, 1}, 0.853)
 
     def test_dataset_boston_housing_pd_cat(self):
-        X, y, fairness_info = lale.lib.aif360.fetch_boston_housing_df(preprocess=False)
+        X, y, fairness_info = lale.lib.aif360._fetch_boston_housing_df(preprocess=False)
         # TODO: consider better way of handling "set_y" parameter for regression problems
         self._attempt_dataset(X, y, fairness_info, 506, 13, set(y), 0.814)
 
     def test_dataset_boston_housing_pd_num(self):
-        X, y, fairness_info = lale.lib.aif360.fetch_boston_housing_df(preprocess=True)
+        X, y, fairness_info = lale.lib.aif360._fetch_boston_housing_df(preprocess=True)
         # TODO: consider better way of handling "set_y" parameter for regression problems
         self._attempt_dataset(X, y, fairness_info, 506, 13, set(y), 0.814)
 
@@ -321,7 +321,7 @@ class TestAIF360Num(unittest.TestCase):
     def _boston_pd_num(cls):
         # TODO: Consider investigating test failure when preprocess is set to True
         # (eo_diff is not less than 0 in this case; perhaps regression model learns differently?)
-        orig_X, orig_y, fairness_info = lale.lib.aif360.fetch_boston_housing_df(
+        orig_X, orig_y, fairness_info = lale.lib.aif360._fetch_boston_housing_df(
             preprocess=False
         )
         train_X, test_X, train_y, test_y = sklearn.model_selection.train_test_split(

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -151,7 +151,7 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_speeddating_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_speeddating_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 8_378, 503, {0, 1}, 0.853)
+        self._attempt_dataset(X, y, fairness_info, 8_378, 70, {0, 1}, 0.853)
 
     def test_dataset_boston_housing_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_boston_housing_df(preprocess=False)

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -169,7 +169,7 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_titanic_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_titanic_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 1_309, 2_828, {0, 1}, 0.254)
+        self._attempt_dataset(X, y, fairness_info, 1_309, 37, {0, 1}, 0.254)
 
     def test_dataset_tae_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_tae_df(preprocess=False)


### PR DESCRIPTION
Upon trying to run a grid search with all in-estimator mitigators against all datasets (new and old), I ran into some runtime issues against the newer datasets based on the preprocessing steps that were taken. As a result, this PR contains some modifications to preprocessing steps that should help all algorithms run to completion and properly fit models. Specifically:
* COMPAS and COMPAS Violent: reduce number of categorical columns and binarize via grouping attributes
* SpeedDating: removing categorical columns and removing columns that would otherwise lead to dataset leakage
* Titanic: removing categorical columns
* TAE: relaxing fairness info to allow for more positive examples in privileged group while training
* Boston: discouraging public use of dataset based on issues described in detail [here](https://medium.com/@docintangible/racist-data-destruction-113e3eff54a8)