### PR TITLE
Disabling autoai_ts_libs tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,9 @@ jobs:
         python-version: [3.7, 3.8]
         setup-target: ['.[full,test]']
         include:
-        - test-case: test/test_autoai_ts_libs.py
-          python-version: 3.7
-          setup-target: '.[test]'
+        # - test-case: test/test_autoai_ts_libs.py
+        #   python-version: 3.7
+        #   setup-target: '.[test]'
         - test-case: test/test_autogen_lib.py
           python-version: 3.6
           setup-target: '.[test]'


### PR DESCRIPTION
Temporarily removed `test/test_autoai_ts_libs.py` from the test matrix until the following error is addressed:

```
_________________ ERROR collecting test/test_autoai_ts_libs.py _________________
ImportError while importing test module '/home/runner/work/lale/lale/test/test_autoai_ts_libs.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/test_autoai_ts_libs.py:28: in <module>
    from lale.lib.autoai_ts_libs import (  # type: ignore # noqa; StandardRowMeanCenterMTS,; WindowTransformerMTS; DifferenceFlattenAutoEnsembler,; FlattenAutoEnsembler,; LocalizedFlattenAutoEnsembler,
lale/lib/autoai_ts_libs/__init__.py:62: in <module>
    from .difference_flatten_auto_ensembler import DifferenceFlattenAutoEnsembler
lale/lib/autoai_ts_libs/difference_flatten_auto_ensembler.py:15: in <module>
    from autoai_ts_libs.srom.estimators.time_series.models.srom_estimators import (  # type: ignore # noqa
autoai_ts_libs/srom/estimators/time_series/models/srom_estimators.py:32: in init autoai_ts_libs.srom.estimators.time_series.models.srom_estimators
    ???
E   ModuleNotFoundError: No module named 'ai4ml_ts.utils'
```