### PR TITLE
Relaxing fairness_info for Titanic dataset

### DIFF
--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -1071,8 +1071,8 @@ def fetch_titanic_df(preprocess=False):
 
     It contains data gathered from passengers on the Titanic with a binary classification
     into "survived" or "did not survive".  Without preprocessing, the dataset has
-    1309 rows and 13 columns.  There are two protected attributes, sex and age, and the
-    disparate impact is 0.25.  The data includes both categorical and
+    1309 rows and 13 columns.  There is one protected attribute, sex, and the
+    disparate impact is 0.26.  The data includes both categorical and
     numeric columns, with some missing values.
 
     .. _`Titanic`: https://www.openml.org/d/40945
@@ -1110,7 +1110,6 @@ def fetch_titanic_df(preprocess=False):
     orig_y = pd.concat([train_y, test_y]).sort_index()
     if preprocess:
         sex = pd.Series(orig_X["sex_female"] == 1, dtype=np.float64)
-        age = pd.Series(orig_X["age"] <= 18, dtype=np.float64)
         columns_to_drop = ["sex_female", "sex_male"]
 
         # drop more columns that turn into gigantic one-hot encodings otherwise, like name and cabin
@@ -1127,12 +1126,11 @@ def fetch_titanic_df(preprocess=False):
             list(filter(extra_categorical_columns_filter, orig_X.columns))
         )
         dropped_X = orig_X.drop(labels=columns_to_drop, axis=1)
-        encoded_X = dropped_X.assign(sex=sex, age=age)
+        encoded_X = dropped_X.assign(sex=sex)
         fairness_info = {
             "favorable_labels": [1],
             "protected_attributes": [
                 {"feature": "sex", "reference_group": [1]},
-                {"feature": "age", "reference_group": [1]},
             ],
         }
         return encoded_X, orig_y, fairness_info
@@ -1141,7 +1139,6 @@ def fetch_titanic_df(preprocess=False):
             "favorable_labels": ["1"],
             "protected_attributes": [
                 {"feature": "sex", "reference_group": ["female"]},
-                {"feature": "age", "reference_group": [[0, 18]]},
             ],
         }
         return orig_X, orig_y, fairness_info

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -165,11 +165,11 @@ class TestAIF360Datasets(unittest.TestCase):
 
     def test_dataset_titanic_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_titanic_df(preprocess=False)
-        self._attempt_dataset(X, y, fairness_info, 1_309, 13, {"0", "1"}, 0.254)
+        self._attempt_dataset(X, y, fairness_info, 1_309, 13, {"0", "1"}, 0.263)
 
     def test_dataset_titanic_pd_num(self):
         X, y, fairness_info = lale.lib.aif360.fetch_titanic_df(preprocess=True)
-        self._attempt_dataset(X, y, fairness_info, 1_309, 37, {0, 1}, 0.254)
+        self._attempt_dataset(X, y, fairness_info, 1_309, 37, {0, 1}, 0.263)
 
     def test_dataset_tae_pd_cat(self):
         X, y, fairness_info = lale.lib.aif360.fetch_tae_df(preprocess=False)


### PR DESCRIPTION
Shifting `fairness_info` to only care about `sex` instead of both `sex` and `age` to hopefully make fitting models easier.