### PR TITLE
Fixes to adversarial debiasing to make it work with scikit-learn's cl…

### DIFF
--- a/lale/lib/aif360/adversarial_debiasing.py
+++ b/lale/lib/aif360/adversarial_debiasing.py
@@ -151,7 +151,7 @@ _hyperparams_schema = {
                     "default": None,
                 },
                 "scope_name": {
-                    "description": "Scope name for the tenforflow variables.",
+                    "description": "Scope name for the tenforflow variables. A unique alpha-numeric suffix is added to this value.",
                     "type": "string",
                     "default": "adversarial_debiasing",
                 },

--- a/lale/lib/aif360/adversarial_debiasing.py
+++ b/lale/lib/aif360/adversarial_debiasing.py
@@ -21,6 +21,8 @@ try:
 except ImportError:
     tensorflow_installed = False
 
+import uuid
+
 import lale.docstrings
 import lale.operators
 
@@ -57,30 +59,48 @@ class _AdversarialDebiasingImpl(_BaseInEstimatorImpl):
 or with
     pip install 'lale[full]'"""
         assert "1.13.1" <= tf.__version__
-        if sess is None:
-            sess = tf.compat.v1.Session()
-        prot_attr_names = [pa["feature"] for pa in protected_attributes]
+        self.scope_name = scope_name
+        self.protected_attributes = protected_attributes
+        self.seed = seed
+        self.sess = sess
+        self.adversary_loss_weight = adversary_loss_weight
+        self.num_epochs = num_epochs
+        self.batch_size = batch_size
+        self.classifier_num_hidden_units = classifier_num_hidden_units
+        self.debias = debias
+        self.favorable_labels = favorable_labels
+        self.redact = redact
+        self.preparation = preparation
+
+    def fit(self, X, y=None):
+        tf.compat.v1.reset_default_graph()
+        if self.sess is None:
+            self.sess = tf.compat.v1.Session()
+
+        prot_attr_names = [pa["feature"] for pa in self.protected_attributes]
         unprivileged_groups = [{name: 0 for name in prot_attr_names}]
         privileged_groups = [{name: 1 for name in prot_attr_names}]
+
         mitigator = aif360.algorithms.inprocessing.AdversarialDebiasing(
             unprivileged_groups=unprivileged_groups,
             privileged_groups=privileged_groups,
-            scope_name=scope_name,
-            sess=sess,
-            seed=seed,
-            adversary_loss_weight=adversary_loss_weight,
-            num_epochs=num_epochs,
-            batch_size=batch_size,
-            classifier_num_hidden_units=classifier_num_hidden_units,
-            debias=debias,
+            scope_name=self.scope_name + str(uuid.uuid4()),
+            sess=self.sess,
+            seed=self.seed,
+            adversary_loss_weight=self.adversary_loss_weight,
+            num_epochs=self.num_epochs,
+            batch_size=self.batch_size,
+            classifier_num_hidden_units=self.classifier_num_hidden_units,
+            debias=self.debias,
         )
         super(_AdversarialDebiasingImpl, self).__init__(
-            favorable_labels=favorable_labels,
-            protected_attributes=protected_attributes,
-            redact=redact,
-            preparation=preparation,
+            favorable_labels=self.favorable_labels,
+            protected_attributes=self.protected_attributes,
+            redact=self.redact,
+            preparation=self.preparation,
             mitigator=mitigator,
         )
+        return super(_AdversarialDebiasingImpl, self).fit(X, y)
 
 
 _input_fit_schema = _categorical_supervised_input_fit_schema

--- a/test/test_aif360_ensembles.py
+++ b/test/test_aif360_ensembles.py
@@ -21,6 +21,7 @@ from lale.lib.aif360 import (
     PrejudiceRemover,
     fair_stratified_train_test_split,
 )
+from lale.lib.aif360.adversarial_debiasing import AdversarialDebiasing
 from lale.lib.aif360.datasets import fetch_creditg_df
 from lale.lib.sklearn import (
     AdaBoostClassifier,
@@ -74,6 +75,15 @@ class TestEnsemblesWithAIF360(unittest.TestCase):
 
     def test_bagging_in_estimator_mitigation_base(self):
         model = BaggingClassifier(base_estimator=PrejudiceRemover(**self.fairness_info))
+        self._attempt_fit_predict(model)
+
+    def test_bagging_in_estimator_mitigation_base_1(self):
+        import tensorflow as tf
+
+        tf.compat.v1.disable_eager_execution()
+        model = BaggingClassifier(
+            base_estimator=AdversarialDebiasing(**self.fairness_info), n_estimators=2
+        )
         self._attempt_fit_predict(model)
 
     def test_bagging_post_estimator_mitigation_base(self):


### PR DESCRIPTION
…one.

AdversarialDebiasing when cloned keeps the same Tensorflow session and variable scope name. This creates an issue when we try to train the clone and throws an error: ```ValueError: Variable adversarial_debiasing/classifier_model/W1 already exists, disallowed. Did you mean to set reuse=True or reuse=tf.AUTO_REUSE in VarScope?```

This issue is observed during its use in ensembles. 
The solution was to reset the tf graph, creating a new session and passing a unique `scope_name` to create a new instance of aif360 AdversarialDebiasing during each call to fit. 

A part of this fix could be avoided (i.e. resetting of the graph and creation of new session) if aif360 accepts: https://github.com/Trusted-AI/AIF360/pull/255