### PR TITLE
Fix to Stacking in case a base estimator produces a NaN value

### DIFF
--- a/lale/lib/sklearn/stacking_utils.py
+++ b/lale/lib/sklearn/stacking_utils.py
@@ -33,4 +33,6 @@ def _concatenate_predictions_pandas(base_stacking, X, predictions):
         idx += 1
     if base_stacking.passthrough:
         X_meta.append(X)
-    return pd.concat(X_meta, axis=1)
+    return pd.concat(X_meta, axis=1).fillna(
+        0
+    )  # on the off-chance an estimator produces a NaN


### PR DESCRIPTION
Specifically with a `MetaFairClassifier` as a base estimator for a StackingClassifier while trying to fit the SpeedDating dataset, the base estimator produces a NaN value for one of the predictions, which causes a downstream data-checking assert to fail and throws off downstream computations. This PR modifies the `_concatenate_predictions_pandas` method to replace NaN values with 0 in the rare case that this should happen (if at all). (Feel free to decline if there is a better solution.)