### PR TITLE
Improve Lale sklearn schema

### DIFF
--- a/lale/lib/sklearn/bagging_classifier.py
+++ b/lale/lib/sklearn/bagging_classifier.py
@@ -221,7 +221,21 @@ _hyperparams_schema = {
                     "description": "Controls the verbosity when fitting and predicting.",
                 },
             },
-        }
+        },
+        {
+            "description": "Out of bag estimation only available if bootstrap=True",
+            "anyOf": [
+                {"type": "object", "properties": {"bootstrap": {"enum": [True]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
+        {
+            "description": "Out of bag estimate only available if warm_start=False",
+            "anyOf": [
+                {"type": "object", "properties": {"warm_start": {"enum": [False]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/bagging_regressor.py
+++ b/lale/lib/sklearn/bagging_regressor.py
@@ -212,7 +212,21 @@ _hyperparams_schema = {
                     "description": "Controls the verbosity when fitting and predicting.",
                 },
             },
-        }
+        },
+        {
+            "description": "Out of bag estimation only available if bootstrap=True",
+            "anyOf": [
+                {"type": "object", "properties": {"bootstrap": {"enum": [True]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
+        {
+            "description": "Out of bag estimate only available if warm_start=False",
+            "anyOf": [
+                {"type": "object", "properties": {"warm_start": {"enum": [False]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/column_transformer.py
+++ b/lale/lib/sklearn/column_transformer.py
@@ -134,7 +134,12 @@ The output of the transformer is multiplied by these weights.""",
                     "default": None,
                 },
             },
-        }
+        },
+        {
+            "description": "A sparse matrix was passed, but dense data is required. Use X.toarray() to convert to a dense numpy array.",
+            "type": "object",
+            "laleNot": "X/isSparse",
+        },
     ]
 }
 

--- a/lale/lib/sklearn/extra_trees_classifier.py
+++ b/lale/lib/sklearn/extra_trees_classifier.py
@@ -213,6 +213,13 @@ _hyperparams_schema = {
             "type": "object",
             "laleNot": "y/isSparse",
         },
+        {
+            "description": "Out of bag estimation only available if bootstrap=True",
+            "anyOf": [
+                {"type": "object", "properties": {"bootstrap": {"enum": [True]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/extra_trees_regressor.py
+++ b/lale/lib/sklearn/extra_trees_regressor.py
@@ -197,7 +197,19 @@ _hyperparams_schema = {
                     "description": "When set to ``True``, reuse the solution of the previous call to fit",
                 },
             },
-        }
+        },
+        {
+            "description": "This classifier does not support sparse labels.",
+            "type": "object",
+            "laleNot": "y/isSparse",
+        },
+        {
+            "description": "Out of bag estimation only available if bootstrap=True",
+            "anyOf": [
+                {"type": "object", "properties": {"bootstrap": {"enum": [True]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/feature_agglomeration.py
+++ b/lale/lib/sklearn/feature_agglomeration.py
@@ -112,6 +112,11 @@ _hyperparams_schema = {
                 },
             ],
         },
+        {
+            "description": "A sparse matrix was passed, but dense data is required. Use X.toarray() to convert to a dense numpy array.",
+            "type": "object",
+            "laleNot": "X/isSparse",
+        },
     ],
 }
 

--- a/lale/lib/sklearn/function_transformer.py
+++ b/lale/lib/sklearn/function_transformer.py
@@ -79,13 +79,14 @@ _hyperparams_schema = {
             },
         },
         {
-            "description": "If validate is False, then accept_sparse has no effect.",
+            "description": "If validate is False, then accept_sparse has no effect. Otherwise, if accept_sparse is false, sparse matrix inputs will cause an exception to be raised.",
             "anyOf": [
+                {"type": "object", "properties": {"validate": {"enum": [False]}}},
+                {"type": "object", "laleNot": "X/isSparse"},
                 {
                     "type": "object",
-                    "properties": {"validate": {"not": {"enum": [False]}}},
+                    "properties": {"accept_sparse": {"not": {"enum": [False]}}},
                 },
-                {"type": "object", "properties": {"accept_sparse": {"enum": [False]}}},
             ],
         },
     ]

--- a/lale/lib/sklearn/function_transformer.py
+++ b/lale/lib/sklearn/function_transformer.py
@@ -85,7 +85,7 @@ _hyperparams_schema = {
                 {"type": "object", "laleNot": "X/isSparse"},
                 {
                     "type": "object",
-                    "properties": {"accept_sparse": {"not": {"enum": [False]}}},
+                    "properties": {"accept_sparse": {"enum": [True]}},
                 },
             ],
         },

--- a/lale/lib/sklearn/gaussian_nb.py
+++ b/lale/lib/sklearn/gaussian_nb.py
@@ -45,7 +45,12 @@ _hyperparams_schema = {
                     "description": "Portion of the largest variance of all features that is added to variances for calculation stability.",
                 },
             },
-        }
+        },
+        {
+            "description": "A sparse matrix was passed, but dense data is required. Use X.toarray() to convert to a dense numpy array.",
+            "type": "object",
+            "laleNot": "X/isSparse",
+        },
     ],
 }
 _input_fit_schema = {

--- a/lale/lib/sklearn/k_neighbors_classifier.py
+++ b/lale/lib/sklearn/k_neighbors_classifier.py
@@ -112,40 +112,6 @@ _hyperparams_schema = {
                 },
             },
         },
-        {
-            "description": "The leaf size only matters for tree algorithms.",
-            "anyOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "algorithm": {"enum": ["ball_tree", "kd_tree"]},
-                    },
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "leaf_size": {"enum": [30]},
-                    },
-                },
-            ],
-        },
-        {
-            "description": "The power parameter is specific to the minkowski metric.",
-            "anyOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "metric": {"enum": ["minkowski"]},
-                    },
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "p": {"enum": [2]},
-                    },
-                },
-            ],
-        },
     ],
 }
 

--- a/lale/lib/sklearn/k_neighbors_regressor.py
+++ b/lale/lib/sklearn/k_neighbors_regressor.py
@@ -112,40 +112,6 @@ _hyperparams_schema = {
                 },
             },
         },
-        {
-            "description": "The leaf size only matters for tree algorithms.",
-            "anyOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "algorithm": {"enum": ["ball_tree", "kd_tree"]},
-                    },
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "leaf_size": {"enum": [30]},
-                    },
-                },
-            ],
-        },
-        {
-            "description": "The power parameter is specific to the minkowski metric.",
-            "anyOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "metric": {"enum": ["minkowski"]},
-                    },
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "p": {"enum": [2]},
-                    },
-                },
-            ],
-        },
     ],
 }
 

--- a/lale/lib/sklearn/linear_svc.py
+++ b/lale/lib/sklearn/linear_svc.py
@@ -146,28 +146,43 @@ _hyperparams_schema = {
             },
         },
         {
-            "description": "The combination of penalty=`l1` and loss=`hinge` is not supported",
+            "description": "The combination of penalty=`l1` and loss=`hinge` is not supported. "
+            "If multi_class='crammer_singer', the options loss, penalty and dual will be ignored.",
             "anyOf": [
                 {"type": "object", "properties": {"penalty": {"enum": ["l2"]}}},
                 {"type": "object", "properties": {"loss": {"enum": ["squared_hinge"]}}},
+                {
+                    "type": "object",
+                    "properties": {"multi_class": {"enum": ["crammer_singer"]}},
+                },
             ],
         },
         {
             "description": "The combination of penalty=`l2` and loss=`hinge` "
-            "is not supported when dual=False.",
+            "is not supported when dual=False. If multi_class='crammer_singer', the options loss, "
+            "penalty and dual will be ignored.",
             "anyOf": [
                 {"type": "object", "properties": {"penalty": {"enum": ["l1"]}}},
                 {"type": "object", "properties": {"loss": {"enum": ["squared_hinge"]}}},
                 {"type": "object", "properties": {"dual": {"enum": [True]}}},
+                {
+                    "type": "object",
+                    "properties": {"multi_class": {"enum": ["crammer_singer"]}},
+                },
             ],
         },
         {
             "description": "The combination of penalty=`l1` and "
-            "loss=`squared_hinge` is not supported when dual=True.",
+            "loss=`squared_hinge` is not supported when dual=True.  If multi_class='crammer_singer', "
+            "the options loss, penalty and dual will be ignored.",
             "anyOf": [
                 {"type": "object", "properties": {"penalty": {"enum": ["l2"]}}},
                 {"type": "object", "properties": {"loss": {"enum": ["hinge"]}}},
                 {"type": "object", "properties": {"dual": {"enum": [False]}}},
+                {
+                    "type": "object",
+                    "properties": {"multi_class": {"enum": ["crammer_singer"]}},
+                },
             ],
         },
     ]

--- a/lale/lib/sklearn/linear_svr.py
+++ b/lale/lib/sklearn/linear_svr.py
@@ -70,9 +70,7 @@ The strength of the regularization is inversely proportional to C. Must be stric
                 },
                 "loss": {
                     "enum": [
-                        "hinge",
                         "squared_epsilon_insensitive",
-                        "squared_hinge",
                         "epsilon_insensitive",
                     ],
                     "default": "epsilon_insensitive",
@@ -126,7 +124,17 @@ Note that this setting takes advantage of a per-process runtime setting in libli
                     "description": "The maximum number of iterations to be run.",
                 },
             },
-        }
+        },
+        {
+            "description": "loss='epsilon_insensitive' is not supported when dual=False.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"loss": {"enum": ["squared_epsilon_insensitive"]}},
+                },
+                {"type": "object", "properties": {"dual": {"enum": [True]}}},
+            ],
+        },
     ],
 }
 _input_fit_schema = {

--- a/lale/lib/sklearn/logistic_regression.py
+++ b/lale/lib/sklearn/logistic_regression.py
@@ -341,6 +341,74 @@ not.""",
                 },
             ],
         },
+        {
+            "description": "penalty='none' is not supported for the liblinear solver",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"solver": {"not": {"enum": ["liblinear"]}}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"penalty": {"not": {"enum": ["none"]}}},
+                },
+            ],
+        },
+        {
+            "description": "When penalty is elasticnet, l1_ratio must be between 0 and 1.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"penalty": {"not": {"enum": ["elasticnet"]}}},
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {"l1_ratio": {"type": "number"}},
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "l1_ratio": {"type": "number", "minimum": 0}
+                            },
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "l1_ratio": {"type": "number", "maximum": 1}
+                            },
+                        },
+                    ]
+                },
+            ],
+        },
+        {
+            "description": "Only 'saga' solver supports elasticnet penalty",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"penalty": {"not": {"enum": ["elasticnet"]}}},
+                },
+                {"type": "object", "properties": {"solver": {"enum": ["saga"]}}},
+            ],
+        },
+        {
+            "description": "The combination of penalty='l1' and loss='logistic_regression' are not supported when dual=True",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"solver": {"not": {"enum": ["liblinear"]}}},
+                },
+                {
+                    "allOf": [
+                        {"type": "object", "properties": {"penalty": {"enum": ["l1"]}}},
+                        {"type": "object", "properties": {"dual": {"enum": [False]}}},
+                    ]
+                },
+                {"type": "object", "properties": {"penalty": {"enum": ["l2"]}}},
+            ],
+        }
         # {
         #     "description": "Penalty elasticnet is only supported by the saga solver.",
         #     "anyOf": [

--- a/lale/lib/sklearn/logistic_regression.py
+++ b/lale/lib/sklearn/logistic_regression.py
@@ -384,22 +384,6 @@ not.""",
                 {"type": "object", "properties": {"solver": {"enum": ["saga"]}}},
             ],
         },
-        {
-            "description": "The combination of penalty='l1' and loss='logistic_regression' are not supported when dual=True",
-            "anyOf": [
-                {
-                    "type": "object",
-                    "properties": {"solver": {"not": {"enum": ["liblinear"]}}},
-                },
-                {
-                    "allOf": [
-                        {"type": "object", "properties": {"penalty": {"enum": ["l1"]}}},
-                        {"type": "object", "properties": {"dual": {"enum": [False]}}},
-                    ]
-                },
-                {"type": "object", "properties": {"penalty": {"enum": ["l2"]}}},
-            ],
-        },
     ],
 }
 

--- a/lale/lib/sklearn/logistic_regression.py
+++ b/lale/lib/sklearn/logistic_regression.py
@@ -362,24 +362,15 @@ not.""",
                     "properties": {"penalty": {"not": {"enum": ["elasticnet"]}}},
                 },
                 {
-                    "allOf": [
-                        {
-                            "type": "object",
-                            "properties": {"l1_ratio": {"type": "number"}},
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "l1_ratio": {"type": "number", "minimum": 0}
-                            },
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "l1_ratio": {"type": "number", "maximum": 1}
-                            },
-                        },
-                    ]
+                    "type": "object",
+                    "properties": {
+                        "l1_ratio": {
+                            "type": "number",
+                            "minimum": 0.0,
+                            "exclusiveMinimum": True,
+                            "maximum": 1.0,
+                        }
+                    },
                 },
             ],
         },
@@ -408,50 +399,7 @@ not.""",
                 },
                 {"type": "object", "properties": {"penalty": {"enum": ["l2"]}}},
             ],
-        }
-        # {
-        #     "description": "Penalty elasticnet is only supported by the saga solver.",
-        #     "anyOf": [
-        #         {
-        #             "type": "object",
-        #             "properties": {"penalty": {"not": {"enum": ["elasticnet"]}}},
-        #         },
-        #         {"type": "object", "properties": {"solver": {"enum": ["saga"]}}},
-        #     ],
-        # },
-        # {
-        #     "description": "When penalty is elasticnet, l1_ratio must be between 0 and 1.",
-        #     "anyOf": [
-        #         {
-        #             "type": "object",
-        #             "properties": {"penalty": {"not": {"enum": ["elasticnet"]}}},
-        #         },
-        #         {
-        #             "type": "object",
-        #             "properties": {
-        #                 "l1_ratio": {
-        #                     "type": "number",
-        #                     "minimum": 0.0,
-        #                     "exclusiveMinimum": True,
-        #                     "maximum": 1.0,
-        #                 }
-        #             },
-        #         },
-        #     ],
-        # },
-        # {
-        #     "description": "Solver liblinear does not support penalty none.",
-        #     "anyOf": [
-        #         {
-        #             "type": "object",
-        #             "properties": {"solver": {"not": {"enum": ["liblinear"]}}},
-        #         },
-        #         {
-        #             "type": "object",
-        #             "properties": {"penalty": {"enum": ["l1", "l2", "elasticnet"]}},
-        #         },
-        #     ],
-        # },
+        },
     ],
 }
 

--- a/lale/lib/sklearn/min_max_scaler.py
+++ b/lale/lib/sklearn/min_max_scaler.py
@@ -91,7 +91,12 @@ _hyperparams_schema = {
                     "default": True,
                 },
             },
-        }
+        },
+        {
+            "description": "MinMaxScaler does not support sparse input. Consider using MaxAbsScaler instead.",
+            "type": "object",
+            "laleNot": "X/isSparse",
+        },
     ],
 }
 

--- a/lale/lib/sklearn/missing_indicator.py
+++ b/lale/lib/sklearn/missing_indicator.py
@@ -71,6 +71,16 @@ _hyperparams_schema = {
                 },
             ],
         },
+        {
+            "description": "Sparse input with missing_values=0 is not supported. Provide a dense array instead.",
+            "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
+                {
+                    "type": "object",
+                    "properties": {"missing_values": {"not": {"enum": [0]}}},
+                },
+            ],
+        },
     ],
 }
 _input_fit_schema = {

--- a/lale/lib/sklearn/one_hot_encoder.py
+++ b/lale/lib/sklearn/one_hot_encoder.py
@@ -14,6 +14,7 @@
 
 import pandas as pd
 import scipy.sparse.csr
+import sklearn
 import sklearn.preprocessing
 
 import lale.docstrings
@@ -185,5 +186,56 @@ class _OneHotEncoderImpl:
 
 
 OneHotEncoder = lale.operators.make_operator(_OneHotEncoderImpl, _combined_schemas)
+
+if sklearn.__version__ >= "0.21":
+    # new: https://scikit-learn.org/0.21/modules/generated/sklearn.preprocessing.OneHotEncoder.html
+    OneHotEncoder = OneHotEncoder.customize_schema(
+        drop={
+            "anyOf": [
+                {"enum": ["first"]},
+                {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "forOptimizer": False,
+                },
+                {"enum": [None]},
+            ],
+            "default": None,
+            "description": "Specifies a methodology to use to drop one of the categories per feature.",
+        },
+        set_as_available=True,
+    )
+    OneHotEncoder = OneHotEncoder.customize_schema(
+        constraint={
+            "description": "'handle_unknown' must be 'error' when the drop parameter is specified, as both would create categories that are all zero.",
+            "anyOf": [
+                {"type": "object", "properties": {"drop": {"enum": [None]}}},
+                {
+                    "type": "object",
+                    "properties": {"handle_unknown": {"enum": ["error"]}},
+                },
+            ],
+        },
+        set_as_available=True,
+    )
+
+if sklearn.__version__ >= "0.23":
+    # new: https://scikit-learn.org/0.23/modules/generated/sklearn.preprocessing.OneHotEncoder.html
+    OneHotEncoder = OneHotEncoder.customize_schema(
+        drop={
+            "anyOf": [
+                {"enum": ["first", "if_binary"]},
+                {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "forOptimizer": False,
+                },
+                {"enum": [None]},
+            ],
+            "default": None,
+            "description": "Specifies a methodology to use to drop one of the categories per feature.",
+        },
+        set_as_available=True,
+    )
 
 lale.docstrings.set_docstrings(OneHotEncoder)

--- a/lale/lib/sklearn/ordinal_encoder.py
+++ b/lale/lib/sklearn/ordinal_encoder.py
@@ -318,7 +318,7 @@ In inverse_transform, an unknown category will be denoted as None.
 When this parameter is set to `ignore` and an unknown category is encountered during transform,
 the resulting encoding with be set to the value indicated by `encode_unknown_with` (this functionality is added by lale).
 """,
-                values=["error", "use_encoded_value"],
+                values=["error", "ignore", "use_encoded_value"],
                 default="error",
             ),
             unknown_value=AnyOf(
@@ -333,13 +333,17 @@ It has to be distinct from the values used to encode any of the categories in fi
     )
     OrdinalEncoder = OrdinalEncoder.customize_schema(
         constraint={
-            "description": "unknown_value should be an integer or np.nan when handle_unknown is 'use_encoded_value'. s",
+            "description": "unknown_value should be an integer or np.nan when handle_unknown is 'use_encoded_value'.",
             "anyOf": [
                 {
                     "type": "object",
                     "properties": {
                         "handle_unknown": {"not": {"enum": ["use_encoded_value"]}}
                     },
+                },
+                {
+                    "type": "object",
+                    "properties": {"unknown_value": {"enum": [np.nan]}},
                 },
                 {
                     "type": "object",

--- a/lale/lib/sklearn/ordinal_encoder.py
+++ b/lale/lib/sklearn/ordinal_encoder.py
@@ -318,7 +318,7 @@ In inverse_transform, an unknown category will be denoted as None.
 When this parameter is set to `ignore` and an unknown category is encountered during transform,
 the resulting encoding with be set to the value indicated by `encode_unknown_with` (this functionality is added by lale).
 """,
-                values=["error", "ignore", "use_encoded_value"],
+                values=["error", "use_encoded_value"],
                 default="error",
             ),
             unknown_value=AnyOf(
@@ -330,6 +330,37 @@ It has to be distinct from the values used to encode any of the categories in fi
             ),
             set_as_available=True,
         ),
+    )
+    OrdinalEncoder = OrdinalEncoder.customize_schema(
+        constraint={
+            "description": "unknown_value should be an integer or np.nan when handle_unknown is 'use_encoded_value'. s",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "handle_unknown": {"not": {"enum": ["use_encoded_value"]}}
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {"unknown_value": {"type": "integer"}},
+                },
+            ],
+        },
+        set_as_available=True,
+    )
+    OrdinalEncoder = OrdinalEncoder.customize_schema(
+        constraint={
+            "description": "unknown_value should only be set when handle_unknown is 'use_encoded_value'.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"handle_unknown": {"enum": ["use_encoded_value"]}},
+                },
+                {"type": "object", "properties": {"unknown_value": {"enum": [None]}}},
+            ],
+        },
+        set_as_available=True,
     )
 
 lale.docstrings.set_docstrings(OrdinalEncoder)

--- a/lale/lib/sklearn/random_forest_classifier.py
+++ b/lale/lib/sklearn/random_forest_classifier.py
@@ -241,6 +241,13 @@ _hyperparams_schema = {
             "type": "object",
             "laleNot": "y/isSparse",
         },
+        {
+            "description": "Out of bag estimation only available if bootstrap=True.",
+            "anyOf": [
+                {"type": "object", "properties": {"bootstrap": {"enum": [True]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/random_forest_regressor.py
+++ b/lale/lib/sklearn/random_forest_regressor.py
@@ -232,7 +232,19 @@ _hyperparams_schema = {
                     "description": "When set to True, reuse the solution of the previous call to fit and add more estimators to the ensemble, otherwise, just fit a whole new forest.",
                 },
             },
-        }
+        },
+        {
+            "description": "This classifier does not support sparse labels.",
+            "type": "object",
+            "laleNot": "y/isSparse",
+        },
+        {
+            "description": "Out of bag estimation only available if bootstrap=True.",
+            "anyOf": [
+                {"type": "object", "properties": {"bootstrap": {"enum": [True]}}},
+                {"type": "object", "properties": {"oob_score": {"enum": [False]}}},
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/ridge.py
+++ b/lale/lib/sklearn/ridge.py
@@ -119,7 +119,28 @@ _hyperparams_schema = {
                     "description": "The seed of the pseudo random number generator to use when shuffling",
                 },
             },
-        }
+        },
+        {
+            "description": "solver {svd, lsqr, cholesky, saga} does not support fitting the intercept on sparse data. Please set the solver to 'auto' or 'sparse_cg', 'sag', or set `fit_intercept=False. ",
+            "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
+                {"type": "object", "properties": {"fit_intercept": {"enum": [False]}}},
+                {
+                    "type": "object",
+                    "properties": {"solver": {"enum": ["auto", "sparse_cg", "sag"]}},
+                },
+            ],
+        },
+        {
+            "description": "SVD solver does not support sparse inputs currently.",
+            "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
+                {
+                    "type": "object",
+                    "properties": {"solver": {"not": {"enum": ["svd"]}}},
+                },
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/ridge_classifier.py
+++ b/lale/lib/sklearn/ridge_classifier.py
@@ -126,27 +126,6 @@ _hyperparams_schema = {
                 },
             },
         },
-        {
-            "description": "solver {svd, lsqr, cholesky, saga} does not support fitting the intercept on sparse data. Please set the solver to 'auto' or 'sparse_cg', 'sag', or set `fit_intercept=False. ",
-            "anyOf": [
-                {"type": "object", "laleNot": "X/isSparse"},
-                {"type": "object", "properties": {"fit_intercept": {"enum": [False]}}},
-                {
-                    "type": "object",
-                    "properties": {"solver": {"enum": ["auto", "sparse_cg", "sag"]}},
-                },
-            ],
-        },
-        {
-            "description": "SVD solver does not support sparse inputs currently.",
-            "anyOf": [
-                {"type": "object", "laleNot": "X/isSparse"},
-                {
-                    "type": "object",
-                    "properties": {"solver": {"not": {"enum": ["svd"]}}},
-                },
-            ],
-        },
     ],
 }
 

--- a/lale/lib/sklearn/ridge_classifier.py
+++ b/lale/lib/sklearn/ridge_classifier.py
@@ -125,7 +125,28 @@ _hyperparams_schema = {
                     "description": "The seed of the pseudo random number generator to use when shuffling",
                 },
             },
-        }
+        },
+        {
+            "description": "solver {svd, lsqr, cholesky, saga} does not support fitting the intercept on sparse data. Please set the solver to 'auto' or 'sparse_cg', 'sag', or set `fit_intercept=False. ",
+            "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
+                {"type": "object", "properties": {"fit_intercept": {"enum": [False]}}},
+                {
+                    "type": "object",
+                    "properties": {"solver": {"enum": ["auto", "sparse_cg", "sag"]}},
+                },
+            ],
+        },
+        {
+            "description": "SVD solver does not support sparse inputs currently.",
+            "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
+                {
+                    "type": "object",
+                    "properties": {"solver": {"not": {"enum": ["svd"]}}},
+                },
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/robust_scaler.py
+++ b/lale/lib/sklearn/robust_scaler.py
@@ -63,7 +63,14 @@ _hyperparams_schema = {
                     "description": "If False, try to avoid a copy and do inplace scaling instead.",
                 },
             },
-        }
+        },
+        {
+            "description": "From /preprocessing/_data.py:RobustScaler:fit, Exception: raise ValueError(     'Cannot center sparse matrices: use `with_centering=False` instead. See docstring for motivation and alternatives.'     ) ",
+            "anyOf": [
+                {"type": "object", "properties": {"with_centering": {"enum": [False]}}},
+                {"type": "object", "laleNot": "X/isSparse"},
+            ],
+        },
     ],
 }
 _input_fit_schema = {

--- a/lale/lib/sklearn/robust_scaler.py
+++ b/lale/lib/sklearn/robust_scaler.py
@@ -65,7 +65,7 @@ _hyperparams_schema = {
             },
         },
         {
-            "description": "From /preprocessing/_data.py:RobustScaler:fit, Exception: raise ValueError(     'Cannot center sparse matrices: use `with_centering=False` instead. See docstring for motivation and alternatives.'     ) ",
+            "description": "Cannot center sparse matrices: use `with_centering=False` instead. See docstring for motivation and alternatives.",
             "anyOf": [
                 {"type": "object", "properties": {"with_centering": {"enum": [False]}}},
                 {"type": "object", "laleNot": "X/isSparse"},

--- a/lale/lib/sklearn/simple_imputer.py
+++ b/lale/lib/sklearn/simple_imputer.py
@@ -110,7 +110,17 @@ _hyperparams_schema = {
                     "description": "If True, a MissingIndicator transform will stack onto output of the imputer’s transform.",
                 },
             },
-        }
+        },
+        {
+            "description": "Imputation not possible when missing_values == 0 and input is sparse. Provide a dense array instead.",
+            "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
+                {
+                    "type": "object",
+                    "properties": {"missing_values": {"not": {"enum": [0]}}},
+                },
+            ],
+        },
     ],
 }
 

--- a/lale/lib/sklearn/svc.py
+++ b/lale/lib/sklearn/svc.py
@@ -168,13 +168,13 @@ _hyperparams_schema = {
             },
         },
         {
-            "description": "coef0 only significant in kernel ‘poly’ and ‘sigmoid’.",
+            "description": "Sparse precomputed kernels are not supported.",
             "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
                 {
                     "type": "object",
-                    "properties": {"kernel": {"enum": ["poly", "sigmoid"]}},
+                    "properties": {"kernel": {"not": {"enum": ["precomputed"]}}},
                 },
-                {"type": "object", "properties": {"coef0": {"enum": [0.0]}}},
             ],
         },
     ]

--- a/lale/lib/sklearn/svr.py
+++ b/lale/lib/sklearn/svr.py
@@ -138,13 +138,13 @@ _hyperparams_schema = {
             },
         },
         {
-            "description": "coef0 only significant in kernel ‘poly’ and ‘sigmoid’.",
+            "description": "Sparse precomputed kernels are not supported.",
             "anyOf": [
+                {"type": "object", "laleNot": "X/isSparse"},
                 {
                     "type": "object",
-                    "properties": {"kernel": {"enum": ["poly", "sigmoid"]}},
+                    "properties": {"kernel": {"not": {"enum": ["precomputed"]}}},
                 },
-                {"type": "object", "properties": {"coef0": {"enum": [0.0]}}},
             ],
         },
     ]

--- a/test/test_core_classifiers.py
+++ b/test/test_core_classifiers.py
@@ -493,7 +493,7 @@ class TestSpuriousSideConstraintsClassification(unittest.TestCase):
         reg.fit(self.X_train, self.y_train)
 
     def test_ridge_classifier(self):
-        reg = RidgeClassifier(fit_intercept=False, normalize=True)
+        reg = RidgeClassifier(fit_intercept=False)
         reg.fit(self.X_train, self.y_train)
 
     def test_ridge_classifier_1(self):

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -381,7 +381,7 @@ class TestHyperopt(unittest.TestCase):
 
         X, y = load_iris(return_X_y=True)
 
-        max_opt_time = 2.0
+        max_opt_time = 10.0
         hoc = Hyperopt(
             estimator=planned_pipeline,
             max_evals=1,

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -830,7 +830,7 @@ class TestGridSearchCV(unittest.TestCase):
 
         X, y = load_iris(return_X_y=True)
 
-        max_opt_time = 2.0
+        max_opt_time = 10.0
         hoc = GridSearchCV(
             estimator=planned_pipeline,
             cv=3,

--- a/test/test_type_checking.py
+++ b/test/test_type_checking.py
@@ -1182,46 +1182,6 @@ class TestHyperparamConstraints(unittest.TestCase):
             with self.assertRaises(jsonschema.ValidationError):
                 RandomForestRegressor(**bad_hyperparams)
 
-    def test_ridge_classifier_1(self):
-        import sklearn
-
-        from lale.lib.sklearn import RidgeClassifier
-
-        bad_X = self.sparse_X
-        y = self.y
-
-        bad_hyperparams = {"fit_intercept": True, "solver": "lsqr"}
-        trainable = sklearn.linear_model.RidgeClassifier(**bad_hyperparams)
-        with self.assertRaisesRegex(
-            ValueError, "does not support fitting the intercept on sparse data."
-        ):
-            trainable.fit(bad_X, self.y)
-
-        trainable = RidgeClassifier(**bad_hyperparams)
-        with EnableSchemaValidation():
-            with self.assertRaises(jsonschema.ValidationError):
-                trainable.fit(bad_X, y)
-
-    def test_ridge_classifier_2(self):
-        import sklearn
-
-        from lale.lib.sklearn import RidgeClassifier
-
-        bad_X = self.sparse_X
-        y = self.y
-
-        bad_hyperparams = {"solver": "svd", "fit_intercept": False}
-        trainable = sklearn.linear_model.RidgeClassifier(**bad_hyperparams)
-        with self.assertRaisesRegex(
-            TypeError, "SVD solver does not support sparse inputs currently"
-        ):
-            trainable.fit(bad_X, self.y)
-
-        trainable = RidgeClassifier(**bad_hyperparams)
-        with EnableSchemaValidation():
-            with self.assertRaises(jsonschema.ValidationError):
-                trainable.fit(bad_X, y)
-
     def test_ridge_1(self):
         import sklearn
 

--- a/test/test_type_checking.py
+++ b/test/test_type_checking.py
@@ -809,6 +809,302 @@ class TestErrorMessages(unittest.TestCase):
             self.assertRegex(fix1, "remove unknown key 'activation'.*set penalty='l2'")
 
 
+class TestHyperparamConstraints(unittest.TestCase):
+    def setUp(self):
+        import scipy.sparse
+        from sklearn.datasets import load_iris
+
+        data = load_iris()
+        X, y = data.data, data.target
+        # self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(X, y)
+
+        sparse_X = scipy.sparse.csr_matrix(X)
+        self.sparse_X = sparse_X
+        self.X = X
+        self.y = y
+
+    def test_bagging_classifier(self):
+        from lale.lib.sklearn import BaggingClassifier
+
+        bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                BaggingClassifier(**bad_hyperparams)
+
+    def test_bagging_classifier_2(self):
+        from lale.lib.sklearn import BaggingClassifier
+
+        bad_hyperparams = {"warm_start": True, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                BaggingClassifier(**bad_hyperparams)
+
+    def test_bagging_regressor(self):
+        from lale.lib.sklearn import BaggingRegressor
+
+        bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                BaggingRegressor(**bad_hyperparams)
+
+    def test_bagging_regressor_2(self):
+        from lale.lib.sklearn import BaggingRegressor
+
+        bad_hyperparams = {"warm_start": True, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                BaggingRegressor(**bad_hyperparams)
+
+    def test_extra_trees_classifier(self):
+        from lale.lib.sklearn import ExtraTreesClassifier
+
+        bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                ExtraTreesClassifier(**bad_hyperparams)
+
+    def test_extra_trees_regressor(self):
+        from lale.lib.sklearn import ExtraTreesRegressor
+
+        bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                ExtraTreesRegressor(**bad_hyperparams)
+
+    def test_function_transformer(self):
+        from lale.lib.sklearn import FunctionTransformer
+
+        bad_hyperparams = {"validate": True, "accept_sparse": False}
+        bad_X = self.sparse_X
+        y = self.y
+        trainable = FunctionTransformer(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_linear_svc_1(self):
+        from lale.lib.sklearn import LinearSVC
+
+        bad_hyperparams = {"penalty": "l1", "loss": "hinge", "multi_class": "ovr"}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LinearSVC(**bad_hyperparams)
+
+    def test_linear_svc_2(self):
+        from lale.lib.sklearn import LinearSVC
+
+        bad_hyperparams = {
+            "penalty": "l2",
+            "loss": "hinge",
+            "dual": False,
+            "multi_class": "ovr",
+        }
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LinearSVC(**bad_hyperparams)
+
+    def test_linear_svc_3(self):
+        from lale.lib.sklearn import LinearSVC
+
+        bad_hyperparams = {
+            "penalty": "l1",
+            "loss": "squared_hinge",
+            "dual": True,
+            "multi_class": "ovr",
+        }
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LinearSVC(**bad_hyperparams)
+
+    def test_linear_svr(self):
+        from lale.lib.sklearn import LinearSVR
+
+        bad_hyperparams = {"loss": "epsilon_insensitive", "dual": False}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LinearSVR(**bad_hyperparams)
+
+    def test_logistic_regression_1(self):
+        from lale.lib.sklearn import LogisticRegression
+
+        bad_hyperparams = {"solver": "liblinear", "penalty": "none"}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LogisticRegression(**bad_hyperparams)
+
+    def test_logistic_regression_2(self):
+        from lale.lib.sklearn import LogisticRegression
+
+        bad_hyperparams = {
+            "penalty": "elasticnet",
+            "l1_ratio": None,
+            "solver": "liblinear",
+        }
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LogisticRegression(**bad_hyperparams)
+
+    def test_logistic_regression_3(self):
+        from lale.lib.sklearn import LogisticRegression
+
+        bad_hyperparams = {
+            "penalty": "elasticnet",
+            "solver": "liblinear",
+            "l1_ratio": 0.5,
+        }
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                LogisticRegression(**bad_hyperparams)
+
+    def test_missing_indicator(self):
+        from lale.lib.sklearn import MissingIndicator
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"missing_values": 0}
+        trainable = MissingIndicator(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_one_hot_encoder(self):
+        from lale.lib.sklearn import OneHotEncoder
+
+        bad_hyperparams = {"drop": "first", "handle_unknown": "ignore"}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                OneHotEncoder(**bad_hyperparams)
+
+    def test_ordinal_encoder_1(self):
+        from lale.lib.sklearn import OrdinalEncoder
+
+        bad_hyperparams = {"handle_unknown": "use_encoded_value", "unknown_value": None}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                OrdinalEncoder(**bad_hyperparams)
+
+    def test_ordinal_encoder_2(self):
+        from lale.lib.sklearn import OrdinalEncoder
+
+        bad_hyperparams = {"handle_unknown": "error", "unknown_value": 1}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                OrdinalEncoder(**bad_hyperparams)
+
+    def test_random_forest_classifier(self):
+        from lale.lib.sklearn import RandomForestClassifier
+
+        bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                RandomForestClassifier(**bad_hyperparams)
+
+    def test_random_forest_regressor(self):
+        from lale.lib.sklearn import RandomForestRegressor
+
+        bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                RandomForestRegressor(**bad_hyperparams)
+
+    def test_ridge_classifier_1(self):
+        from lale.lib.sklearn import RidgeClassifier
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"fit_intercept": True, "solver": "lsqr"}
+        trainable = RidgeClassifier(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_ridge_classifier_2(self):
+        from lale.lib.sklearn import RidgeClassifier
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"solver": "svd", "fit_intercept": False}
+        trainable = RidgeClassifier(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_ridge_1(self):
+        from lale.lib.sklearn import Ridge
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"fit_intercept": True, "solver": "lsqr"}
+        trainable = Ridge(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_ridge_2(self):
+        from lale.lib.sklearn import Ridge
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"solver": "svd", "fit_intercept": False}
+        trainable = Ridge(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_robust_scaler(self):
+        from lale.lib.sklearn import RobustScaler
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"with_centering": True}
+        trainable = RobustScaler(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_simple_imputer(self):
+        from lale.lib.sklearn import SimpleImputer
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"missing_values": 0}
+        trainable = SimpleImputer(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_svc(self):
+        from lale.lib.sklearn import SVC
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"kernel": "precomputed"}
+        trainable = SVC(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+    def test_svr(self):
+        from lale.lib.sklearn import SVR
+
+        bad_X = self.sparse_X
+        y = self.y
+
+        bad_hyperparams = {"kernel": "precomputed"}
+        trainable = SVR(**bad_hyperparams)
+        with EnableSchemaValidation():
+            with self.assertRaises(jsonschema.ValidationError):
+                trainable.fit(bad_X, y)
+
+
 class TestSchemaValidation(unittest.TestCase):
     def test_any(self):
         from lale.type_checking import is_subschema

--- a/test/test_type_checking.py
+++ b/test/test_type_checking.py
@@ -1116,34 +1116,39 @@ class TestHyperparamConstraints(unittest.TestCase):
 
         from lale.lib.sklearn import OrdinalEncoder
 
-        bad_hyperparams = {"handle_unknown": "use_encoded_value", "unknown_value": None}
-        trainable = sklearn.preprocessing.OrdinalEncoder(**bad_hyperparams)
-        with self.assertRaisesRegex(
-            TypeError,
-            "unknown_value should be an integer or np.nan when handle_unknown is 'use_encoded_value'",
-        ):
-            trainable.fit(self.X, self.y)
+        if sklearn.__version__ >= "0.24.1":
+            bad_hyperparams = {
+                "handle_unknown": "use_encoded_value",
+                "unknown_value": None,
+            }
+            trainable = sklearn.preprocessing.OrdinalEncoder(**bad_hyperparams)
+            with self.assertRaisesRegex(
+                TypeError,
+                "unknown_value should be an integer or np.nan when handle_unknown is 'use_encoded_value'",
+            ):
+                trainable.fit(self.X, self.y)
 
-        with EnableSchemaValidation():
-            with self.assertRaises(jsonschema.ValidationError):
-                OrdinalEncoder(**bad_hyperparams)
+            with EnableSchemaValidation():
+                with self.assertRaises(jsonschema.ValidationError):
+                    OrdinalEncoder(**bad_hyperparams)
 
     def test_ordinal_encoder_2(self):
         import sklearn
 
         from lale.lib.sklearn import OrdinalEncoder
 
-        bad_hyperparams = {"handle_unknown": "error", "unknown_value": 1}
-        trainable = sklearn.preprocessing.OrdinalEncoder(**bad_hyperparams)
-        with self.assertRaisesRegex(
-            TypeError,
-            "unknown_value should only be set when handle_unknown is 'use_encoded_value'",
-        ):
-            trainable.fit(self.X, self.y)
+        if sklearn.__version__ >= "0.24.1":
+            bad_hyperparams = {"handle_unknown": "error", "unknown_value": 1}
+            trainable = sklearn.preprocessing.OrdinalEncoder(**bad_hyperparams)
+            with self.assertRaisesRegex(
+                TypeError,
+                "unknown_value should only be set when handle_unknown is 'use_encoded_value'",
+            ):
+                trainable.fit(self.X, self.y)
 
-        with EnableSchemaValidation():
-            with self.assertRaises(jsonschema.ValidationError):
-                OrdinalEncoder(**bad_hyperparams)
+            with EnableSchemaValidation():
+                with self.assertRaises(jsonschema.ValidationError):
+                    OrdinalEncoder(**bad_hyperparams)
 
     def test_random_forest_classifier(self):
         import sklearn

--- a/test/test_type_checking.py
+++ b/test/test_type_checking.py
@@ -812,85 +812,156 @@ class TestErrorMessages(unittest.TestCase):
 class TestHyperparamConstraints(unittest.TestCase):
     def setUp(self):
         import scipy.sparse
-        from sklearn.datasets import load_iris
+        import sklearn.datasets
 
-        data = load_iris()
+        data = sklearn.datasets.load_iris()
         X, y = data.data, data.target
-        # self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(X, y)
 
         sparse_X = scipy.sparse.csr_matrix(X)
         self.sparse_X = sparse_X
         self.X = X
         self.y = y
 
+        self.regression_X, self.regression_y = sklearn.datasets.make_regression(
+            n_features=4, n_informative=2, random_state=0, shuffle=False
+        )
+
     def test_bagging_classifier(self):
+        import sklearn
+
         from lale.lib.sklearn import BaggingClassifier
 
         bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        trainable = sklearn.ensemble.BaggingClassifier(**bad_hyperparams)
+
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimation only available if bootstrap=True"
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 BaggingClassifier(**bad_hyperparams)
 
     def test_bagging_classifier_2(self):
+        import sklearn
+
         from lale.lib.sklearn import BaggingClassifier
 
         bad_hyperparams = {"warm_start": True, "oob_score": True}
+        trainable = sklearn.ensemble.BaggingClassifier(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimate only available if warm_start=False"
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 BaggingClassifier(**bad_hyperparams)
 
     def test_bagging_regressor(self):
+        import sklearn
+
         from lale.lib.sklearn import BaggingRegressor
 
         bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        trainable = sklearn.ensemble.BaggingRegressor(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimation only available if bootstrap=True"
+        ):
+            trainable.fit(self.regression_X, self.regression_y)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 BaggingRegressor(**bad_hyperparams)
 
     def test_bagging_regressor_2(self):
+        import sklearn
+
         from lale.lib.sklearn import BaggingRegressor
 
         bad_hyperparams = {"warm_start": True, "oob_score": True}
+        trainable = sklearn.ensemble.BaggingRegressor(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimate only available if warm_start=False"
+        ):
+            trainable.fit(self.regression_X, self.regression_y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 BaggingRegressor(**bad_hyperparams)
 
     def test_extra_trees_classifier(self):
+        import sklearn
+
         from lale.lib.sklearn import ExtraTreesClassifier
 
         bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        trainable = sklearn.ensemble.ExtraTreesClassifier(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimation only available if bootstrap=True"
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 ExtraTreesClassifier(**bad_hyperparams)
 
     def test_extra_trees_regressor(self):
+        import sklearn
+
         from lale.lib.sklearn import ExtraTreesRegressor
 
         bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        trainable = sklearn.ensemble.ExtraTreesRegressor(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimation only available if bootstrap=True"
+        ):
+            trainable.fit(self.regression_X, self.regression_y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 ExtraTreesRegressor(**bad_hyperparams)
 
     def test_function_transformer(self):
+        import sklearn
+
         from lale.lib.sklearn import FunctionTransformer
 
         bad_hyperparams = {"validate": True, "accept_sparse": False}
         bad_X = self.sparse_X
         y = self.y
+
+        trainable = sklearn.preprocessing.FunctionTransformer(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError, "A sparse matrix was passed, but dense data is required."
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = FunctionTransformer(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_linear_svc_1(self):
+        import sklearn
+
         from lale.lib.sklearn import LinearSVC
 
         bad_hyperparams = {"penalty": "l1", "loss": "hinge", "multi_class": "ovr"}
+        trainable = sklearn.svm.LinearSVC(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "The combination of penalty='l1' and loss='hinge' is not supported",
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LinearSVC(**bad_hyperparams)
 
     def test_linear_svc_2(self):
+        import sklearn
+
         from lale.lib.sklearn import LinearSVC
 
         bad_hyperparams = {
@@ -899,11 +970,20 @@ class TestHyperparamConstraints(unittest.TestCase):
             "dual": False,
             "multi_class": "ovr",
         }
+        trainable = sklearn.svm.LinearSVC(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "The combination of penalty='l2' and loss='hinge' are not supported when dual=False",
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LinearSVC(**bad_hyperparams)
 
     def test_linear_svc_3(self):
+        import sklearn
+
         from lale.lib.sklearn import LinearSVC
 
         bad_hyperparams = {
@@ -912,39 +992,71 @@ class TestHyperparamConstraints(unittest.TestCase):
             "dual": True,
             "multi_class": "ovr",
         }
+        trainable = sklearn.svm.LinearSVC(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "The combination of penalty='l1' and loss='squared_hinge' are not supported when dual=True",
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LinearSVC(**bad_hyperparams)
 
     def test_linear_svr(self):
+        import sklearn
+
         from lale.lib.sklearn import LinearSVR
 
         bad_hyperparams = {"loss": "epsilon_insensitive", "dual": False}
+        trainable = sklearn.svm.LinearSVR(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "The combination of penalty='l2' and loss='epsilon_insensitive' are not supported when dual=False",
+        ):
+            trainable.fit(self.regression_X, self.regression_y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LinearSVR(**bad_hyperparams)
 
     def test_logistic_regression_1(self):
+        import sklearn
+
         from lale.lib.sklearn import LogisticRegression
 
         bad_hyperparams = {"solver": "liblinear", "penalty": "none"}
+        trainable = sklearn.linear_model.LogisticRegression(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "penalty='none' is not supported for the liblinear solver"
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LogisticRegression(**bad_hyperparams)
 
     def test_logistic_regression_2(self):
+        import sklearn
+
         from lale.lib.sklearn import LogisticRegression
 
         bad_hyperparams = {
             "penalty": "elasticnet",
             "l1_ratio": None,
-            "solver": "liblinear",
+            "solver": "saga",
         }
+        trainable = sklearn.linear_model.LogisticRegression(**bad_hyperparams)
+        with self.assertRaisesRegex(ValueError, "l1_ratio must be between 0 and 1"):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LogisticRegression(**bad_hyperparams)
 
     def test_logistic_regression_3(self):
+        import sklearn
+
         from lale.lib.sklearn import LogisticRegression
 
         bad_hyperparams = {
@@ -952,153 +1064,276 @@ class TestHyperparamConstraints(unittest.TestCase):
             "solver": "liblinear",
             "l1_ratio": 0.5,
         }
+        trainable = sklearn.linear_model.LogisticRegression(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Only 'saga' solver supports elasticnet penalty"
+        ):
+            trainable.fit(self.X, self.y)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 LogisticRegression(**bad_hyperparams)
 
     def test_missing_indicator(self):
+        import sklearn
+
         from lale.lib.sklearn import MissingIndicator
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"missing_values": 0}
+
+        trainable = sklearn.impute.MissingIndicator(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Sparse input with missing_values=0 is not supported."
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = MissingIndicator(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_one_hot_encoder(self):
+        import sklearn
+
         from lale.lib.sklearn import OneHotEncoder
 
         bad_hyperparams = {"drop": "first", "handle_unknown": "ignore"}
+        trainable = sklearn.preprocessing.OneHotEncoder(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "`handle_unknown` must be 'error' when the drop parameter is specified",
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 OneHotEncoder(**bad_hyperparams)
 
     def test_ordinal_encoder_1(self):
+        import sklearn
+
         from lale.lib.sklearn import OrdinalEncoder
 
         bad_hyperparams = {"handle_unknown": "use_encoded_value", "unknown_value": None}
+        trainable = sklearn.preprocessing.OrdinalEncoder(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError,
+            "unknown_value should be an integer or np.nan when handle_unknown is 'use_encoded_value'",
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 OrdinalEncoder(**bad_hyperparams)
 
     def test_ordinal_encoder_2(self):
+        import sklearn
+
         from lale.lib.sklearn import OrdinalEncoder
 
         bad_hyperparams = {"handle_unknown": "error", "unknown_value": 1}
+        trainable = sklearn.preprocessing.OrdinalEncoder(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError,
+            "unknown_value should only be set when handle_unknown is 'use_encoded_value'",
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 OrdinalEncoder(**bad_hyperparams)
 
     def test_random_forest_classifier(self):
+        import sklearn
+
         from lale.lib.sklearn import RandomForestClassifier
 
         bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        trainable = sklearn.ensemble.RandomForestClassifier(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimation only available if bootstrap=True"
+        ):
+            trainable.fit(self.X, self.y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 RandomForestClassifier(**bad_hyperparams)
 
     def test_random_forest_regressor(self):
+        import sklearn
+
         from lale.lib.sklearn import RandomForestRegressor
 
         bad_hyperparams = {"bootstrap": False, "oob_score": True}
+        trainable = sklearn.ensemble.RandomForestRegressor(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "Out of bag estimation only available if bootstrap=True"
+        ):
+            trainable.fit(self.regression_X, self.regression_y)
+
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 RandomForestRegressor(**bad_hyperparams)
 
     def test_ridge_classifier_1(self):
+        import sklearn
+
         from lale.lib.sklearn import RidgeClassifier
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"fit_intercept": True, "solver": "lsqr"}
+        trainable = sklearn.linear_model.RidgeClassifier(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "does not support fitting the intercept on sparse data."
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = RidgeClassifier(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_ridge_classifier_2(self):
+        import sklearn
+
         from lale.lib.sklearn import RidgeClassifier
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"solver": "svd", "fit_intercept": False}
+        trainable = sklearn.linear_model.RidgeClassifier(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError, "SVD solver does not support sparse inputs currently"
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = RidgeClassifier(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_ridge_1(self):
+        import sklearn
+
         from lale.lib.sklearn import Ridge
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"fit_intercept": True, "solver": "lsqr"}
+        trainable = sklearn.linear_model.Ridge(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError, "does not support fitting the intercept on sparse data."
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = Ridge(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_ridge_2(self):
+        import sklearn
+
         from lale.lib.sklearn import Ridge
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"solver": "svd", "fit_intercept": False}
+        trainable = sklearn.linear_model.Ridge(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError, "SVD solver does not support sparse inputs currently"
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = Ridge(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_robust_scaler(self):
+        import sklearn
+
         from lale.lib.sklearn import RobustScaler
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"with_centering": True}
+        trainable = sklearn.preprocessing.RobustScaler(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Cannot center sparse matrices: use `with_centering=False` instead.",
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = RobustScaler(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_simple_imputer(self):
+        import sklearn
+
         from lale.lib.sklearn import SimpleImputer
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"missing_values": 0}
+        trainable = sklearn.impute.SimpleImputer(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Imputation not possible when missing_values == 0 and input is sparse.",
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = SimpleImputer(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_svc(self):
+        import sklearn
+
         from lale.lib.sklearn import SVC
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"kernel": "precomputed"}
+        trainable = sklearn.svm.SVC(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError, "Sparse precomputed kernels are not supported."
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = SVC(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):
                 trainable.fit(bad_X, y)
 
     def test_svr(self):
+        import sklearn
+
         from lale.lib.sklearn import SVR
 
         bad_X = self.sparse_X
         y = self.y
 
         bad_hyperparams = {"kernel": "precomputed"}
+        trainable = sklearn.svm.SVR(**bad_hyperparams)
+        with self.assertRaisesRegex(
+            TypeError, "Sparse precomputed kernels are not supported."
+        ):
+            trainable.fit(bad_X, self.y)
+
         trainable = SVR(**bad_hyperparams)
         with EnableSchemaValidation():
             with self.assertRaises(jsonschema.ValidationError):


### PR DESCRIPTION
- BaggingClassifier - Add 2 constraints.
- BaggingRegressor - Add 2 constraints.
- ColumnTransformer - Add a sparse constraint.
- ExtraTreesClassifier - Add a constraint.
- ExtraTreesRegressor - Add 2 constraints.
- FeatureAgglomeration - Add a sparse constraint.
- FunctionTransformer - Fix a constraint.
- GaussianNB - Add a sparse constraint.
- KNeighborsClassifier - Remove 2 constraints (false negatives).
- KNeighborsRegressor - Remove 2 constraints (false negatives).
  - For KNN-C and KNN-R, this constraint might be useful but the schema is long and contains many TODOs.

> Metric 'minkowski' not valid for sparse input. Use sorted(sklearn.neighbors.VALID_METRICS_SPARSE['brute']) to get valid options. Metric can also be a callable function.

- LinearSVC - Improve constaints.
- LinearSVR - Modify "loss" schema. Add a constraint.
- LogisticRegression - Add 4 constaints. 
- MinMaxScaler - Add a sparse constraint.
- MissingIndicator - Add a constraint.
- OneHotEncoder - Add "drop" schema, new in 0.21. Add a constraint.
- OrdinalEncoder - Remove "ignore" from "handle_unknown" schema. Add 2 constraints.
- RandomForestClassifier - Add a constraint.
- RandomForestRegressor - Add 2 constraints.
- RidgeClassifier - Add 2 constraints.
- Ridge - Add 2 constraints.
- RobustScaler - Add a constraint.
- SimpleImputer - Add a constraint.
- SVC - Remove a constraint (false negative). Add a constraint.
- SVR - Remove a constraint (false negative). Add a constraint.