### PR TITLE
Change operator impl method to return the wrapped model, if any.  Add…

### DIFF
--- a/lale/lib/lale/grid_search_cv.py
+++ b/lale/lib/lale/grid_search_cv.py
@@ -166,11 +166,13 @@ class _GridSearchCVImpl:
             except BaseException as e:
                 if obs is not None:
                     assert isinstance(obs, Observing)  # type: ignore
-                    impl = observed_op.impl  # type: ignore
+                    impl = observed_op.shallow_impl  # type: ignore
                     impl.failObserving("optimize", e)
                 raise
 
-            impl = getattr(be, "impl", None)
+            impl = None
+            if isinstance(be, lale.operators.Operator):
+                impl = be._impl_instance()
             if impl is not None:
                 assert isinstance(be, Observing)  # type: ignore
                 be = impl.getOp()

--- a/lale/lib/lale/halving_grid_search_cv.py
+++ b/lale/lib/lale/halving_grid_search_cv.py
@@ -189,11 +189,13 @@ class _HalvingGridSearchCVImpl:
             except BaseException as e:
                 if obs is not None:
                     assert isinstance(observed_op, Observing)  # type: ignore
-                    impl = observed_op.impl  # type: ignore
+                    impl = observed_op.shallow_impl  # type: ignore
                     impl.failObserving("optimize", e)
                 raise
 
-            impl = getattr(be, "impl", None)
+            impl = None
+            if isinstance(be, lale.operators.Operator):
+                impl = be._impl_instance()
             if impl is not None:
                 assert isinstance(be, Observing)  # type: ignore
                 be = impl.getOp()

--- a/lale/lib/lale/optimize_last.py
+++ b/lale/lib/lale/optimize_last.py
@@ -62,7 +62,7 @@ class _OptimizeLast:
         )
 
     def __getattr__(self, item):
-        return getattr(self._suffix_optimizer.impl, item)
+        return getattr(self._suffix_optimizer.shallow_impl, item)
 
     def fit(self, X_train, y_train=None, **kwargs):
         return self._suffix_optimizer.fit(X_train, y_train, **kwargs)

--- a/test/test_core_misc.py
+++ b/test/test_core_misc.py
@@ -219,6 +219,20 @@ class TestMethodParameters(unittest.TestCase):
 #        self.assertEqual(trained.steps()[1].impl._fit_params.get("fit_version", None), 5)
 
 
+class TestWrappedImpl(unittest.TestCase):
+    def test_impl(self):
+        import sklearn.preprocessing._encoders as skohe
+
+        ohe = OneHotEncoder()
+        self.assertIsInstance(ohe.impl, skohe.OneHotEncoder)
+
+    def test_shallow_impl(self):
+        import lale.lib.sklearn.one_hot_encoder as lohe
+
+        ohe = OneHotEncoder()
+        self.assertIsInstance(ohe.shallow_impl, lohe._OneHotEncoderImpl)
+
+
 class TestOperatorLogging(unittest.TestCase):
     def setUp(self):
         self.old_level = Ops.logger.level


### PR DESCRIPTION
… shallow_impl to avoid this auto-dereferencing.  Change _final_estimator to not be lazy about impl creation