### PR TITLE
diff() feature with tests

### DIFF
--- a/lale/operators.py
+++ b/lale/operators.py
@@ -146,6 +146,7 @@ Since lale supports richer structures, we conservatively extend this scheme as f
 """
 
 import copy
+import difflib
 import enum as enumeration
 import importlib
 import inspect
@@ -155,7 +156,6 @@ import os
 import shutil
 import sys
 import warnings
-import difflib
 from abc import abstractmethod
 from types import MappingProxyType
 from typing import (
@@ -453,7 +453,8 @@ class Operator(metaclass=AbstractVisitorMeta):
             markdown = IPython.display.Markdown(f"```python\n{result}\n```")
             return IPython.display.display(markdown)
 
-    def diff(self,
+    def diff(
+        self,
         other: Union[Any, "Operator"],
         show_imports: bool = True,
         customize_schema: bool = True,
@@ -483,11 +484,19 @@ class Operator(metaclass=AbstractVisitorMeta):
             If called with ipython_display=False, return pretty-printed diff as a Python string.
         """
 
-        self_str = self.pretty_print(customize_schema=customize_schema, show_imports=show_imports, ipython_display=False)
-        self_lines = self_str.splitlines()
+        self_str = self.pretty_print(
+            customize_schema=customize_schema,
+            show_imports=show_imports,
+            ipython_display=False,
+        )
+        self_lines = self_str.splitlines()  # type: ignore
 
-        other_str = other.pretty_print(customize_schema=customize_schema, show_imports=show_imports, ipython_display=False)
-        other_lines = other_str.splitlines()
+        other_str = other.pretty_print(
+            customize_schema=customize_schema,
+            show_imports=show_imports,
+            ipython_display=False,
+        )
+        other_lines = other_str.splitlines()  # type: ignore
 
         differ = difflib.Differ()
         compare = differ.compare(self_lines, other_lines)
@@ -500,7 +509,6 @@ class Operator(metaclass=AbstractVisitorMeta):
 
             markdown = IPython.display.Markdown(f"```diff\n{compare_str}\n```")
             return IPython.display.display(markdown)
-        return
 
     @abstractmethod
     def _has_same_impl(self, other: "Operator") -> bool:

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -455,10 +455,10 @@ class Operator(metaclass=AbstractVisitorMeta):
 
     def diff(
         self,
-        other: Union[Any, "Operator"],
+        other: "Operator",
         show_imports: bool = True,
         customize_schema: bool = True,
-        ipython_display: bool = True,
+        ipython_display: bool = False,
     ):
         """Displays a diff between this operator and the given other operator.
 
@@ -470,13 +470,12 @@ class Operator(metaclass=AbstractVisitorMeta):
         show_imports : bool, default True
             Whether to include import statements in the pretty-printed code.
 
-        customize_schema : bool, default False
+        customize_schema : bool, default True
             If True, then individual operators whose schema differs from the lale.lib version of the operator will be printed with calls to `customize_schema` that reproduce this difference.
 
-        ipython_display : bool, default True
-            If True, proactively ask Jupyter to render the graph.
-            Otherwise, the graph will only be rendered when visualize()
-            was called in the last statement in a notebook cell.
+        ipython_display : bool, default False
+            If True, will display Markdown-formatted diff string in Jupyter notebook.
+            If False, returns pretty-printing diff as Python string.
 
         Returns
         -------
@@ -502,7 +501,7 @@ class Operator(metaclass=AbstractVisitorMeta):
         compare = differ.compare(self_lines, other_lines)
 
         compare_str = "\n".join(compare)
-        if ipython_display is False:
+        if not ipython_display:
             return compare_str
         else:
             import IPython.display

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -457,7 +457,7 @@ class Operator(metaclass=AbstractVisitorMeta):
         self,
         other: "Operator",
         show_imports: bool = True,
-        customize_schema: bool = True,
+        customize_schema: bool = False,
         ipython_display: bool = False,
     ):
         """Displays a diff between this operator and the given other operator.
@@ -470,7 +470,7 @@ class Operator(metaclass=AbstractVisitorMeta):
         show_imports : bool, default True
             Whether to include import statements in the pretty-printed code.
 
-        customize_schema : bool, default True
+        customize_schema : bool, default False
             If True, then individual operators whose schema differs from the lale.lib version of the operator will be printed with calls to `customize_schema` that reproduce this difference.
 
         ipython_display : bool, default False

--- a/test/test_json_pretty_viz.py
+++ b/test/test_json_pretty_viz.py
@@ -1417,10 +1417,7 @@ class TestDiff(unittest.TestCase):
         single_op = LogisticRegression()
         single_op_schema = single_op.customize_schema(solver={"enum": ["saga"]})
 
-        expected_diff_no_imports = (
-            "- pipeline = LogisticRegression()\n"
-            '+ pipeline = LogisticRegression.customize_schema(solver={"enum": ["saga"]})()'
-        )
+        expected_diff_no_imports = "  pipeline = LogisticRegression()"
         diff_str_no_imports = single_op.diff(
             single_op_schema, show_imports=False, ipython_display=False
         )
@@ -1431,9 +1428,10 @@ class TestDiff(unittest.TestCase):
             "  import lale\n"
             "  \n"
             "  lale.wrap_imported_operators()\n"
-            "  pipeline = LogisticRegression()"
+            "- pipeline = LogisticRegression()\n"
+            '+ pipeline = LogisticRegression.customize_schema(solver={"enum": ["saga"]})()'
         )
         diff_str_no_schema = single_op.diff(
-            single_op_schema, customize_schema=False, ipython_display=False
+            single_op_schema, customize_schema=True, ipython_display=False
         )
         self.assertEqual(diff_str_no_schema, expected_diff_no_schema)

--- a/test/test_json_pretty_viz.py
+++ b/test/test_json_pretty_viz.py
@@ -1310,97 +1310,104 @@ class TestToAndFromJSON(unittest.TestCase):
         json_2 = to_json(operator_2)
         self.assertEqual(json, json_2)
 
-class TestDiff(unittest.TestCase):
 
+class TestDiff(unittest.TestCase):
     def test_single_op(self):
         from lale.lib.sklearn import LogisticRegression
 
         single_op = LogisticRegression()
-        single_op_param = LogisticRegression(solver='saga')
+        single_op_param = LogisticRegression(solver="saga")
 
-        expected_diff = ('  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '- pipeline = LogisticRegression()\n'
-        '+ pipeline = LogisticRegression(solver="saga")\n'
-        '?                               +++++++++++++\n')
+        expected_diff = (
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            "- pipeline = LogisticRegression()\n"
+            '+ pipeline = LogisticRegression(solver="saga")\n'
+            "?                               +++++++++++++\n"
+        )
         diff_str = single_op.diff(single_op_param, ipython_display=False)
         self.assertEqual(diff_str, expected_diff)
 
-        expected_diff_reverse = ('  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '- pipeline = LogisticRegression(solver="saga")\n'
-        '?                               -------------\n\n'
-        '+ pipeline = LogisticRegression()')
+        expected_diff_reverse = (
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            '- pipeline = LogisticRegression(solver="saga")\n'
+            "?                               -------------\n\n"
+            "+ pipeline = LogisticRegression()"
+        )
         diff_str_reverse = single_op_param.diff(single_op, ipython_display=False)
         self.assertEqual(diff_str_reverse, expected_diff_reverse)
 
     def test_pipeline(self):
-        from lale.lib.sklearn import LogisticRegression
-        from lale.lib.sklearn import PCA
-        from lale.lib.sklearn import SelectKBest
         from lale.lib.lale import NoOp
+        from lale.lib.sklearn import PCA, LogisticRegression, SelectKBest
 
         pipeline_simple = PCA >> SelectKBest >> LogisticRegression
-        pipeline_choice = (PCA| NoOp) >> SelectKBest >> LogisticRegression
+        pipeline_choice = (PCA | NoOp) >> SelectKBest >> LogisticRegression
 
-        expected_diff = ('  from sklearn.decomposition import PCA\n'
-        '+ from lale.lib.lale import NoOp\n'
-        '  from sklearn.feature_selection import SelectKBest\n'
-        '  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '- pipeline = PCA >> SelectKBest >> LogisticRegression\n'
-        '+ pipeline = (PCA | NoOp) >> SelectKBest >> LogisticRegression\n'
-        '?            +   ++++++++\n')
+        expected_diff = (
+            "  from sklearn.decomposition import PCA\n"
+            "+ from lale.lib.lale import NoOp\n"
+            "  from sklearn.feature_selection import SelectKBest\n"
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            "- pipeline = PCA >> SelectKBest >> LogisticRegression\n"
+            "+ pipeline = (PCA | NoOp) >> SelectKBest >> LogisticRegression\n"
+            "?            +   ++++++++\n"
+        )
         diff_str = pipeline_simple.diff(pipeline_choice, ipython_display=False)
         self.assertEqual(diff_str, expected_diff)
 
-        expected_diff_reverse = ('  from sklearn.decomposition import PCA\n'
-        '- from lale.lib.lale import NoOp\n'
-        '  from sklearn.feature_selection import SelectKBest\n'
-        '  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '- pipeline = (PCA | NoOp) >> SelectKBest >> LogisticRegression\n'
-        '?            -   --------\n\n'
-        '+ pipeline = PCA >> SelectKBest >> LogisticRegression')
+        expected_diff_reverse = (
+            "  from sklearn.decomposition import PCA\n"
+            "- from lale.lib.lale import NoOp\n"
+            "  from sklearn.feature_selection import SelectKBest\n"
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            "- pipeline = (PCA | NoOp) >> SelectKBest >> LogisticRegression\n"
+            "?            -   --------\n\n"
+            "+ pipeline = PCA >> SelectKBest >> LogisticRegression"
+        )
         diff_str_reverse = pipeline_choice.diff(pipeline_simple, ipython_display=False)
         self.assertEqual(diff_str_reverse, expected_diff_reverse)
 
     def test_single_op_pipeline(self):
-        from lale.lib.sklearn import LogisticRegression
-        from lale.lib.sklearn import PCA
-        from lale.lib.sklearn import SelectKBest
-        from lale.lib.lale import NoOp
+        from lale.lib.sklearn import PCA, LogisticRegression, SelectKBest
 
         single_op = LogisticRegression()
         pipeline = PCA >> SelectKBest >> LogisticRegression
 
-        expected_diff = ('+ from sklearn.decomposition import PCA\n'
-        '+ from sklearn.feature_selection import SelectKBest\n'
-        '  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '- pipeline = LogisticRegression()\n'
-        '+ pipeline = PCA >> SelectKBest >> LogisticRegression')
+        expected_diff = (
+            "+ from sklearn.decomposition import PCA\n"
+            "+ from sklearn.feature_selection import SelectKBest\n"
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            "- pipeline = LogisticRegression()\n"
+            "+ pipeline = PCA >> SelectKBest >> LogisticRegression"
+        )
         diff_str = single_op.diff(pipeline, ipython_display=False)
         self.assertEqual(expected_diff, diff_str)
 
-        expected_diff_reverse = ('- from sklearn.decomposition import PCA\n'
-        '- from sklearn.feature_selection import SelectKBest\n'
-        '  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '- pipeline = PCA >> SelectKBest >> LogisticRegression\n'
-        '+ pipeline = LogisticRegression()')
+        expected_diff_reverse = (
+            "- from sklearn.decomposition import PCA\n"
+            "- from sklearn.feature_selection import SelectKBest\n"
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            "- pipeline = PCA >> SelectKBest >> LogisticRegression\n"
+            "+ pipeline = LogisticRegression()"
+        )
         diff_str_reverse = pipeline.diff(single_op, ipython_display=False)
         self.assertEqual(expected_diff_reverse, diff_str_reverse)
 
@@ -1408,19 +1415,25 @@ class TestDiff(unittest.TestCase):
         from lale.lib.sklearn import LogisticRegression
 
         single_op = LogisticRegression()
-        single_op_schema = single_op.customize_schema(
-            solver={"enum": ["saga"]}
-        )
+        single_op_schema = single_op.customize_schema(solver={"enum": ["saga"]})
 
-        expected_diff_no_imports = ('- pipeline = LogisticRegression()\n'
-        '+ pipeline = LogisticRegression.customize_schema(solver={"enum": ["saga"]})()')
-        diff_str_no_imports = single_op.diff(single_op_schema, show_imports=False, ipython_display=False)
+        expected_diff_no_imports = (
+            "- pipeline = LogisticRegression()\n"
+            '+ pipeline = LogisticRegression.customize_schema(solver={"enum": ["saga"]})()'
+        )
+        diff_str_no_imports = single_op.diff(
+            single_op_schema, show_imports=False, ipython_display=False
+        )
         self.assertEqual(diff_str_no_imports, expected_diff_no_imports)
 
-        expected_diff_no_schema = ('  from sklearn.linear_model import LogisticRegression\n'
-        '  import lale\n'
-        '  \n'
-        '  lale.wrap_imported_operators()\n'
-        '  pipeline = LogisticRegression()')
-        diff_str_no_schema = single_op.diff(single_op_schema, customize_schema=False, ipython_display=False)
+        expected_diff_no_schema = (
+            "  from sklearn.linear_model import LogisticRegression\n"
+            "  import lale\n"
+            "  \n"
+            "  lale.wrap_imported_operators()\n"
+            "  pipeline = LogisticRegression()"
+        )
+        diff_str_no_schema = single_op.diff(
+            single_op_schema, customize_schema=False, ipython_display=False
+        )
         self.assertEqual(diff_str_no_schema, expected_diff_no_schema)


### PR DESCRIPTION
diff() feature takes an operator and generates a diff with the other operator. Useful when modifying an existing pipeline through customize_schema or the (upcoming) replace() feature and examining what changed. By default, displays Markdown diff for notebooks. 

Tests were added to tests/test_json_pretty_viz.py