### PR TITLE
Refresh of schemas for snapml==1.8.0

### DIFF
--- a/lale/lib/snapml/snap_random_forest_classifier.py
+++ b/lale/lib/snapml/snap_random_forest_classifier.py
@@ -39,6 +39,7 @@ class _SnapRandomForestClassifierImpl:
         hist_nbins=256,
         use_gpu=False,
         gpu_ids=None,
+        compress_trees=False,
     ):
         assert (
             snapml_installed
@@ -57,6 +58,7 @@ class _SnapRandomForestClassifierImpl:
             "hist_nbins": hist_nbins,
             "use_gpu": use_gpu,
             "gpu_ids": gpu_ids,
+            "compress_trees": compress_trees,
         }
         modified_hps = {**self._hyperparams}
         if modified_hps["gpu_ids"] is None:
@@ -209,6 +211,11 @@ _hyperparams_schema = {
                     ],
                     "default": None,
                     "description": "Device IDs of the GPUs which will be used when GPU acceleration is enabled.",
+                },
+                "compress_trees": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Compress trees after training for fast inference.",
                 },
             },
         },

--- a/lale/lib/snapml/snap_random_forest_regressor.py
+++ b/lale/lib/snapml/snap_random_forest_regressor.py
@@ -39,6 +39,7 @@ class _SnapRandomForestRegressorImpl:
         hist_nbins=256,
         use_gpu=False,
         gpu_ids=None,
+        compress_trees=False,
     ):
         assert (
             snapml_installed
@@ -57,6 +58,7 @@ class _SnapRandomForestRegressorImpl:
             "hist_nbins": hist_nbins,
             "use_gpu": use_gpu,
             "gpu_ids": gpu_ids,
+            "compress_trees": compress_trees,
         }
         modified_hps = {**self._hyperparams}
         if modified_hps["gpu_ids"] is None:
@@ -205,6 +207,11 @@ _hyperparams_schema = {
                     ],
                     "default": None,
                     "description": "Device IDs of the GPUs which will be used when GPU acceleration is enabled.",
+                },
+                "compress_trees": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Compress trees after training for fast inference.",
                 },
             },
         },

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require = {
     "full": [
         "xgboost<=1.3.3",
         "lightgbm",
-        "snapml>=1.7.0rc3",
+        "snapml>=1.8.0",
         "liac-arff>=2.4.0",
         "tensorflow==2.4.0",
         "smac<=0.10.0",

--- a/test/test_snapml.py
+++ b/test/test_snapml.py
@@ -38,49 +38,59 @@ class TestSnapMLClassifiers(unittest.TestCase):
             _ = scorer(clf, self.test_X, self.test_y)
 
     def test_decision_tree_classifier(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapDecisionTreeClassifier()
-        trained = trainable.fit(self.train_X, self.train_y)
-        for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
-            scorer = sklearn.metrics.make_scorer(metric)
-            _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapDecisionTreeClassifier().get_params()]:
+            trainable = lale.lib.snapml.SnapDecisionTreeClassifier(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
+                scorer = sklearn.metrics.make_scorer(metric)
+                _ = scorer(trained, self.test_X, self.test_y)
 
     def test_random_forest_classifier(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapRandomForestClassifier()
-        trained = trainable.fit(self.train_X, self.train_y)
-        for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
-            scorer = sklearn.metrics.make_scorer(metric)
-            _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapRandomForestClassifier().get_params()]:
+            trainable = lale.lib.snapml.SnapRandomForestClassifier(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
+                scorer = sklearn.metrics.make_scorer(metric)
+                _ = scorer(trained, self.test_X, self.test_y)
 
     def test_boosting_machine_classifier(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapBoostingMachineClassifier()
-        trained = trainable.fit(self.train_X, self.train_y)
-        for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
-            scorer = sklearn.metrics.make_scorer(metric)
-            _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapBoostingMachineClassifier().get_params()]:
+            trainable = lale.lib.snapml.SnapBoostingMachineClassifier(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
+                scorer = sklearn.metrics.make_scorer(metric)
+                _ = scorer(trained, self.test_X, self.test_y)
 
     def test_logistic_regression(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapLogisticRegression()
-        trained = trainable.fit(self.train_X, self.train_y)
-        for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
-            scorer = sklearn.metrics.make_scorer(metric)
-            _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapLogisticRegression().get_params()]:
+            trainable = lale.lib.snapml.SnapLogisticRegression(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
+                scorer = sklearn.metrics.make_scorer(metric)
+                _ = scorer(trained, self.test_X, self.test_y)
 
     def test_support_vector_machine(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapSVMClassifier()
-        trained = trainable.fit(self.train_X, self.train_y)
-        for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
-            scorer = sklearn.metrics.make_scorer(metric)
-            _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapSVMClassifier().get_params()]:
+            trainable = lale.lib.snapml.SnapSVMClassifier(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            for metric in [sklearn.metrics.accuracy_score, sklearn.metrics.roc_auc_score]:
+                scorer = sklearn.metrics.make_scorer(metric)
+                _ = scorer(trained, self.test_X, self.test_y)
 
 
 class TestSnapMLRegressors(unittest.TestCase):
@@ -92,33 +102,41 @@ class TestSnapMLRegressors(unittest.TestCase):
         self.train_X, self.test_X, self.train_y, self.test_y = train_test_split(X, y)
 
     def test_decision_tree_regressor(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapDecisionTreeRegressor()
-        trained = trainable.fit(self.train_X, self.train_y)
-        scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
-        _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapDecisionTreeRegressor().get_params()]:
+            trainable = lale.lib.snapml.SnapDecisionTreeRegressor(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
+            _ = scorer(trained, self.test_X, self.test_y)
 
     def test_linear_regression(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapLinearRegression()
-        trained = trainable.fit(self.train_X, self.train_y)
-        scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
-        _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.LinearRegression().get_params()]:
+            trainable = lale.lib.snapml.SnapLinearRegression(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
+            _ = scorer(trained, self.test_X, self.test_y)
 
     def test_random_forest_regressor(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapRandomForestRegressor()
-        trained = trainable.fit(self.train_X, self.train_y)
-        scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
-        _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapRandomForestRegressor().get_params()]:
+            trainable = lale.lib.snapml.SnapRandomForestRegressor(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
+            _ = scorer(trained, self.test_X, self.test_y)
 
     def test_boosting_machine_regressor(self):
+        import snapml
         import lale.lib.snapml
 
-        trainable = lale.lib.snapml.SnapBoostingMachineRegressor()
-        trained = trainable.fit(self.train_X, self.train_y)
-        scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
-        _ = scorer(trained, self.test_X, self.test_y)
+        for params in [{}, snapml.SnapBoostingMachineRegressor().get_params()]:
+            trainable = lale.lib.snapml.SnapBoostingMachineRegressor(**params)
+            trained = trainable.fit(self.train_X, self.train_y)
+            scorer = sklearn.metrics.make_scorer(sklearn.metrics.r2_score)
+            _ = scorer(trained, self.test_X, self.test_y)


### PR DESCRIPTION
Changes
1. Add `compress_trees` parameter to schemas for RandomForestClassifier and RandomForestRegressor
2. Change `gpu_id` to `gpu_ids` in the BoostingMachineClassifier
3. Update the tests to try passing the default parameter dict from snapml to the Lale-wrapped operators (this was needed to catch the compres_trees issue.