### PR TITLE
Expression validator in Map

### DIFF
--- a/lale/expressions.py
+++ b/lale/expressions.py
@@ -425,3 +425,31 @@ def desc(column: Union[Expr, str]) -> Expr:
 
 
 it = Expr(ast.Name(id="it"))
+
+
+def _it_column(expr):
+    if isinstance(expr, ast.Attribute):
+        if _is_ast_name_it(expr.value):
+            return expr.attr
+        else:
+            raise ValueError(
+                f"Illegal {fixedUnparse(expr)}. Only the access to `it` is supported"
+            )
+    elif isinstance(expr, ast.Subscript):
+        if _is_ast_name_it(expr.value) and isinstance(expr.slice, ast.Index):
+            if isinstance(expr.slice.value, ast.Constant):
+                return expr.slice.value.value
+            elif isinstance(expr.slice.value, ast.Str):
+                return expr.slice.value.s
+        else:
+            raise ValueError(
+                f"Illegal {fixedUnparse(expr)}. Only the access to `it` is supported"
+            )
+    else:
+        raise ValueError(
+            f"Illegal {fixedUnparse(expr)}. Only the access to `it` is supported"
+        )
+
+
+def _is_ast_name_it(expr):
+    return isinstance(expr, ast.Name) and expr.id == "it"

--- a/lale/helpers.py
+++ b/lale/helpers.py
@@ -1131,10 +1131,6 @@ def _is_ast_name(expr):
     return isinstance(expr, ast.Name)
 
 
-def _is_ast_name_it(expr):
-    return isinstance(expr, ast.Name) and expr.id == "it"
-
-
 def _ast_func_id(expr):
     if isinstance(expr, ast.Name):
         return expr.id

--- a/lale/lib/lale/map.py
+++ b/lale/lib/lale/map.py
@@ -19,11 +19,11 @@ import pandas as pd
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
+from lale.expressions import AstExpr, _it_column
 from lale.helpers import (
     _is_ast_attribute,
     _is_ast_call,
     _is_ast_name,
-    _is_ast_name_it,
     _is_pandas_df,
     _is_spark_df,
 )
@@ -69,30 +69,47 @@ def _new_column_name(name, expr):
         return name
 
 
+def _accessed_columns(expr):
+    visitor = _AccessedColumns()
+    visitor.visit(expr._expr)
+    return visitor.accessed
+
+
 class _AccessedColumns(ast.NodeVisitor):
     def __init__(self):
         self.accessed = set()
 
     def visit_Attribute(self, node: ast.Attribute):
-        if _is_ast_name_it(node.value):
-            self.accessed.add(node.attr)
-        else:
-            raise ValueError("Unimplemented expression")
+        self.accessed.add(_it_column(node))
 
     def visit_Subscript(self, node: ast.Subscript):
-        if _is_ast_name_it(node.value) and isinstance(node.slice, ast.Index):
-            if isinstance(node.slice.value, ast.Constant):
-                self.accessed.add(node.slice.value.value)
-            elif isinstance(node.slice.value, ast.Str):
-                self.accessed.add(node.slice.value.s)
-        else:
-            raise ValueError("Unimplemented expression")
+        self.accessed.add(_it_column(node))
 
 
-def accessed_columns(expr):
-    visitor = _AccessedColumns()
+def _validate(X, expr):
+    visitor = _Validate(X)
     visitor.visit(expr._expr)
-    return visitor.accessed
+
+
+class _Validate(ast.NodeVisitor):
+    def __init__(self, X):
+        self.df = X
+
+    def visit_Attribute(self, node: ast.Attribute):
+        column_name = _it_column(node)
+        if column_name not in self.df.columns:
+            raise ValueError(
+                f"The column {column_name} is not present in the dataframe"
+            )
+
+    def visit_Subscript(self, node: ast.Subscript):
+        column_name = _it_column(node)
+        if column_name is None or not column_name.strip():
+            raise ValueError("Name of the column cannot be None or empty.")
+        if column_name not in self.df.columns:
+            raise ValueError(
+                f"The column {column_name} is not present in the dataframe"
+            )
 
 
 class _MapImpl:
@@ -115,11 +132,12 @@ class _MapImpl:
         accessed_column_names = set()
 
         def get_map_function_output(column, new_column_name):
+            _validate(X, column)
             new_column_name = _new_column_name(new_column_name, column)
             new_column = eval_expr_pandas_df(X, column)
             mapped_df[new_column_name] = new_column
             accessed_column_names.add(new_column_name)
-            accessed_column_names.update(accessed_columns(column))
+            accessed_column_names.update(_accessed_columns(column))
 
         if isinstance(self.columns, list):
             for column in self.columns:
@@ -141,11 +159,12 @@ class _MapImpl:
         accessed_column_names = set()
 
         def get_map_function_expr(column, new_column_name):
+            _validate(X, column)
             new_column_name = _new_column_name(new_column_name, column)
             new_column = eval_expr_spark_df(column)  # type: ignore
             new_columns.append(new_column.alias(new_column_name))  # type: ignore
             accessed_column_names.add(new_column_name)
-            accessed_column_names.update(accessed_columns(column))
+            accessed_column_names.update(_accessed_columns(column))
 
         if isinstance(self.columns, list):
             for column in self.columns:

--- a/lale/lib/lale/map.py
+++ b/lale/lib/lale/map.py
@@ -19,7 +19,7 @@ import pandas as pd
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
-from lale.expressions import AstExpr, _it_column
+from lale.expressions import _it_column
 from lale.helpers import (
     _is_ast_attribute,
     _is_ast_call,

--- a/lale/lib/rasl/_eval_spark_df.py
+++ b/lale/lib/rasl/_eval_spark_df.py
@@ -66,11 +66,11 @@ class _SparkEvaluator(ast.NodeVisitor):
 
     def visit_Attribute(self, node: ast.Attribute):
         column_name = _it_column(node)
-        self.result = col(column_name)
+        self.result = col(column_name)  # type: ignore
 
     def visit_Subscript(self, node: ast.Subscript):
         column_name = _it_column(node)
-        self.result = col(column_name)
+        self.result = col(column_name)  # type: ignore
 
     def visit_BinOp(self, node: ast.BinOp):
         self.visit(node.left)

--- a/lale/lib/rasl/_eval_spark_df.py
+++ b/lale/lib/rasl/_eval_spark_df.py
@@ -16,8 +16,8 @@ import ast
 import importlib
 from itertools import chain
 
-from lale.expressions import AstExpr, Expr
-from lale.helpers import _ast_func_id, _is_ast_name_it
+from lale.expressions import AstExpr, Expr, _it_column
+from lale.helpers import _ast_func_id
 
 try:
     # noqa in the imports here because those get used dynamically and flake fails.
@@ -64,20 +64,13 @@ class _SparkEvaluator(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant):
         self.result = lit(node.value)
 
-    def visit_Subscript(self, node: ast.Subscript):
-        if _is_ast_name_it(node.value):
-            column_name = node.slice.value.s  # type: ignore
-            if column_name is None or not column_name.strip():
-                raise ValueError("Name of the column cannot be None or empty.")
-            self.result = col(column_name)
-        else:
-            raise ValueError("Unimplemented expression")
-
     def visit_Attribute(self, node: ast.Attribute):
-        if _is_ast_name_it(node.value):
-            self.result = col(node.attr)
-        else:
-            raise ValueError("Unimplemented expression")
+        column_name = _it_column(node)
+        self.result = col(column_name)
+
+    def visit_Subscript(self, node: ast.Subscript):
+        column_name = _it_column(node)
+        self.result = col(column_name)
 
     def visit_BinOp(self, node: ast.BinOp):
         self.visit(node.left)

--- a/test/test_relational.py
+++ b/test/test_relational.py
@@ -1266,6 +1266,10 @@ class TestMap(unittest.TestCase):
             trainable = Map(columns=[it.gender])
             trained = trainable.fit(df)
             _ = trained.transform(df)
+        with self.assertRaises(ValueError):
+            trainable = Map(columns=[it.dummy])
+            trained = trainable.fit(df)
+            _ = trained.transform(df)
 
     def test_transform_replace_list_and_remainder(self):
         d = {


### PR DESCRIPTION
Add a pass in the `Map` operator that validate the expression to map before executing it. It allows early and uniform error detection independent of the backend.