### PR TITLE
Changes to pretty_print a Pipeline even if there is just a single ste…

### DIFF
--- a/lale/pretty_print.py
+++ b/lale/pretty_print.py
@@ -405,6 +405,8 @@ def _introduce_structure(pipeline: JSON_TYPE, gen: _CodeGenState) -> JSON_TYPE:
         return result
 
     def find_and_replace(graph: JSON_TYPE) -> JSON_TYPE:
+        if len(graph["steps"]) == 1:  # singleton
+            return {"kind": "Seq", "steps": graph["steps"]}
         progress = True
         while progress:
             seq = find_seq(graph)


### PR DESCRIPTION
…p in a pipeline.

The output of `pretty_print` would have an individual object for the case when a pipeline has only a single node. This PR changes the behavior so that we output a `Pipeline` with a single node.