### PR TITLE
use make_pipeline in `pretty_print` of a pipeline with a single node.

### DIFF
--- a/lale/pretty_print.py
+++ b/lale/pretty_print.py
@@ -476,6 +476,10 @@ def _operator_jsn_to_string_rec(uid: str, jsn: JSON_TYPE, gen: _CodeGenState) ->
                 for step_uid, step_val in jsn["steps"].items()
             }
             combinator = _OP_KIND_TO_COMBINATOR[_op_kind(jsn)]
+            if len(printed_steps.values()) == 1 and combinator == ">>":
+                gen.imports.append(f"from lale.operators import make_pipeline")
+                op_expr = "{}({})".format("make_pipeline", ", ".join(printed_steps.values()))
+                return op_expr
             return f" {combinator} ".join(printed_steps.values())
         else:
             printed_steps = {

--- a/lale/pretty_print.py
+++ b/lale/pretty_print.py
@@ -477,8 +477,8 @@ def _operator_jsn_to_string_rec(uid: str, jsn: JSON_TYPE, gen: _CodeGenState) ->
             }
             combinator = _OP_KIND_TO_COMBINATOR[_op_kind(jsn)]
             if len(printed_steps.values()) == 1 and combinator == ">>":
-                gen.imports.append(f"from lale.operators import make_pipeline")
-                op_expr = "{}({})".format("make_pipeline", ", ".join(printed_steps.values()))
+                gen.imports.append("from lale.operators import make_pipeline")
+                op_expr = "make_pipeline({})".format(", ".join(printed_steps.values()))
                 return op_expr
             return f" {combinator} ".join(printed_steps.values())
         else:


### PR DESCRIPTION
Current pretty_print code relied on string join for generating the output with combinators. i.e. `f" {combinator} ".join(printed_steps.values())`. This breaks when there is only one step in the pipeline. This PR adds a check for this condition and uses `make_pipeline` to generate the output string instead.