### PR TITLE
Fixing map to allow integer column names.

### DIFF
--- a/lale/lib/rasl/map.py
+++ b/lale/lib/rasl/map.py
@@ -107,7 +107,9 @@ class _Validate(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript):
         column_name = _it_column(node)
-        if column_name is None or not column_name.strip():
+        if column_name is None or (
+            isinstance(column_name, str) and not column_name.strip()
+        ):
             raise ValueError("Name of the column cannot be None or empty.")
         if column_name not in self.df.columns:
             raise ValueError(


### PR DESCRIPTION
In lale.lib.rasl._Accuracy, we create a column name subscript using `get_columns(y_true)[0]`. This created a column name `0` which was type `int` in lale.lib.rasl.map.visit_Subscript. The PR adds a check for type str before calling `strip`. 