### PR TITLE
Refactored the test cases for SplitXY and changed the handling of Spark dataframe.

### DIFF
--- a/lale/lib/rasl/split_xy.py
+++ b/lale/lib/rasl/split_xy.py
@@ -31,8 +31,10 @@ class _SplitXyImpl:
             y = pd.DataFrame(X[self.label_name])
             X = X.drop(self.label_name, axis=1)
         elif _is_spark_df(X):
-            y = X.select(X[self.label_name])
-            X = X.drop(self.label_name)
+            X = (
+                X.toPandas()
+            )  # This operator is meant to be used with scikit-learn compatible pipelines, so converting to pandas.
+            return self.split_df(X)
         else:
             raise ValueError(
                 "Only Pandas or Spark dataframe are supported as inputs. Please check that pyspark is installed if you see this error for a Spark dataframe."

--- a/lale/lib/rasl/split_xy.py
+++ b/lale/lib/rasl/split_xy.py
@@ -94,7 +94,7 @@ _input_fit_schema = {
         "X": {
             "description": "Features; the outer array is over samples.",
             "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
+            "items": {"type": "array", "items": {"laleType": "Any"}},
         },
     },
 }
@@ -107,7 +107,7 @@ _input_transform_schema = {
         "X": {
             "description": "Features; the outer array is over samples.",
             "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
+            "items": {"type": "array", "items": {"laleType": "Any"}},
         },
     },
 }
@@ -125,7 +125,7 @@ _input_predict_schema = {
         "X": {
             "description": "Features; the outer array is over samples.",
             "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
+            "items": {"type": "array", "items": {"laleType": "Any"}},
         }
     },
 }
@@ -143,7 +143,7 @@ _input_predict_proba_schema = {
         "X": {
             "description": "Features; the outer array is over samples.",
             "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
+            "items": {"type": "array", "items": {"laleType": "Any"}},
         }
     },
 }
@@ -161,7 +161,7 @@ _input_decision_function_schema = {
         "X": {
             "description": "Features; the outer array is over samples.",
             "type": "array",
-            "items": {"type": "array", "items": {"type": "number"}},
+            "items": {"type": "array", "items": {"laleType": "Any"}},
         }
     },
 }

--- a/test/test_relational.py
+++ b/test/test_relational.py
@@ -2313,9 +2313,6 @@ class TestSplitXy(unittest.TestCase):
         _ = trained.predict(self.X_test)
 
 
-@unittest.skip(
-    "skipping because we don't have any estimators that handle a Spark dataframe."
-)
 class TestSplitXySpark(unittest.TestCase):
     def setUp(self):
         if spark_installed:

--- a/test/test_relational.py
+++ b/test/test_relational.py
@@ -2285,70 +2285,41 @@ class TestOrderBy(unittest.TestCase):
 
 
 class TestSplitXy(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUp(cls):
         data = load_iris()
         X, y = data.data, data.target
-        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
+        X_train, X_test, y_train, y_test = train_test_split(
             pd.DataFrame(X), pd.DataFrame(y)
         )
-        self.combined_df = pd.concat([self.X_train, self.y_train], axis=1)
-        self.combined_df.columns = [
+        combined_df = pd.concat([X_train, y_train], axis=1)
+        combined_df.columns = [
             "sepal_length",
             "sepal_width",
             "petal_length",
             "petal_width",
             "class",
         ]
+        spark_df = pandas2spark(combined_df)
+        cls.tgt2datasets = {
+            "pandas": combined_df,
+            "spark": spark_df,
+            "spark-with-index": SparkDataFrameWithIndex(spark_df),
+        }
 
     def test_split_transform(self):
         pipeline = PCA()
-        trainable = SplitXy(operator=pipeline, label_name="class")
-        trained = trainable.fit(self.combined_df)
-        _ = trained.transform(self.combined_df)
+        for _, df in self.tgt2datasets.items():
+            trainable = SplitXy(operator=pipeline, label_name="class")
+            trained = trainable.fit(df)
+            _ = trained.transform(df)
 
     def test_split_predict(self):
         pipeline = PCA() >> LogisticRegression(random_state=42)
-        trainable = SplitXy(operator=pipeline, label_name="class")
-        trained = trainable.fit(self.combined_df)
-        _ = trained.predict(self.X_test)
-
-
-class TestSplitXySpark(unittest.TestCase):
-    def setUp(self):
-        if spark_installed:
-            conf = (
-                SparkConf()
-                .setMaster("local[2]")
-                .set("spark.driver.bindAddress", "127.0.0.1")
-            )
-            sc = SparkContext.getOrCreate(conf=conf)
-            self.sqlCtx = SQLContext(sc)
-            data = load_iris()
-            X, y = data.data, data.target
-            self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
-                pd.DataFrame(X), pd.DataFrame(y)
-            )
-            self.combined_df = pd.concat([self.X_train, self.y_train], axis=1)
-            self.combined_df.columns = [
-                "sepal_length",
-                "sepal_width",
-                "petal_length",
-                "petal_width",
-                "class",
-            ]
-            self.combined_df_spark = self.sqlCtx.createDataFrame(self.combined_df)
-
-    def test_split_spark_transform(self):
-        pipeline = PCA()
-        trainable = SplitXy(operator=pipeline, label_name="class")
-        trained = trainable.fit(self.combined_df_spark)
-        _ = trained.transform(self.combined_df_spark)
-
-    def test_split_spark_predict(self):
-        pipeline = PCA() >> LogisticRegression(random_state=42)
-        trainable = SplitXy(operator=pipeline, label_name="class")
-        trained = trainable.fit(self.combined_df)
-        _ = trained.predict(pd.DataFrame(self.X_test))
+        for _, df in self.tgt2datasets.items():
+            trainable = SplitXy(operator=pipeline, label_name="class")
+            trained = trainable.fit(df)
+            _ = trained.predict(df)
 
 
 class TestTrainTestSplit(unittest.TestCase):


### PR DESCRIPTION
This operator is meant to be used with scikit-learn compatible pipelines, so converting to pandas when the input data is a Spark dataframe.