### PR TITLE
adding seed as a param

### DIFF
--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -648,7 +648,7 @@ numeric_data_types_list = ["numeric", "integer", "real"]
 
 
 def fetch(
-    dataset_name, task_type, verbose=False, preprocess=True, test_size=0.33, astype=None
+        dataset_name, task_type, verbose=False, preprocess=True, test_size=0.33, astype=None, seed=0
 ):
     if verbose:
         print("Loading dataset:", dataset_name)
@@ -797,7 +797,7 @@ def fetch(
         y = pd.Series(y, name=target_col)
 
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=test_size, random_state=0
+        X, y, test_size=test_size, random_state=seed
     )
     if verbose:
         print(f"training set shapes: X {X_train.shape}, y {y_train.shape}")

--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -648,7 +648,7 @@ numeric_data_types_list = ["numeric", "integer", "real"]
 
 
 def fetch(
-        dataset_name, task_type, verbose=False, preprocess=True, test_size=0.33, astype=None, seed=0
+    dataset_name, task_type, verbose=False, preprocess=True, test_size=0.33, astype=None, seed=0
 ):
     if verbose:
         print("Loading dataset:", dataset_name)

--- a/lale/datasets/openml/openml_datasets.py
+++ b/lale/datasets/openml/openml_datasets.py
@@ -648,7 +648,13 @@ numeric_data_types_list = ["numeric", "integer", "real"]
 
 
 def fetch(
-    dataset_name, task_type, verbose=False, preprocess=True, test_size=0.33, astype=None, seed=0
+    dataset_name,
+    task_type,
+    verbose=False,
+    preprocess=True,
+    test_size=0.33,
+    astype=None,
+    seed=0,
 ):
     if verbose:
         print("Loading dataset:", dataset_name)


### PR DESCRIPTION
Hello, currently when fetching datasets from openml, the dataset is split into train and test using a fixed seed 0 - if one re- does an AutoML experiment several times, it would be useful if the seed could be set each time separately.