### PR TITLE
Added an option `freeze_trained_prefix` to partial_fit of pipelines.

### DIFF
--- a/lale/operators.py
+++ b/lale/operators.py
@@ -4876,9 +4876,14 @@ class TrainedPipeline(TrainablePipeline[TrainedOpType], TrainedOperator):
         else:
             transformed_X = transformed_output
             transformed_y = y
-        trained_sink_node = sink_node.partial_fit(
-            transformed_X, transformed_y, classes=classes, **fit_params
-        )
+        try:
+            trained_sink_node = sink_node.partial_fit(
+                transformed_X, transformed_y, classes=classes, **fit_params
+            )
+        except TypeError:  # occurs when `classes` is not expected
+            trained_sink_node = sink_node.partial_fit(
+                transformed_X, transformed_y, **fit_params
+            )
         trained_pipeline = pipeline_prefix >> trained_sink_node
         return trained_pipeline
 

--- a/lale/operators.py
+++ b/lale/operators.py
@@ -4377,11 +4377,13 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
         return TrainedPipeline(trained_steps, trained_edges, _lale_trained=True)
 
     def partial_fit(
-        self, X, y=None, unsafe=False, **fit_params
+        self, X, y=None, freeze_trained_prefix=True, unsafe=False, **fit_params
     ) -> "TrainedPipeline[TrainedIndividualOp]":
         """partial_fit for a pipeline.
         This method assumes that all but the last node of a pipeline are frozen_trained and
         only the last node needs to be fit using its partial_fit method.
+        If that is not the case, and `freeze_trained_prefix` is True, it freezes the prefix
+        of the pipeline except the last node if they are trained.
 
         Parameters
         ----------
@@ -4389,6 +4391,9 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
             Features; see partial_fit schema of the last node.
         y:
             Labels/target
+        freeze_trained_prefix:
+            If True, all but the last node are freeze_trained and only
+            the last node is partial_fit.
         unsafe:
             boolean.
             This flag allows users to override the validation that throws an error when the
@@ -4409,10 +4414,11 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
         for operator in self._steps[:-1]:
             if not operator.is_frozen_trained():
                 estimator_only = False
-        if not estimator_only:
+        if not estimator_only and not freeze_trained_prefix:
             raise ValueError(
                 """partial_fit is only supported on pipelines when all but the last node are frozen_trained and
-        only the last node needs to be fit using its partial_fit method."""
+            only the last node needs to be fit using its partial_fit method. The parameter `freeze_trained_prefix`
+            can be set to True if the prefix is trained and needs to be frozen during partial_fit."""
             )
         if hasattr(self, "_trained"):
             # This is the case where partial_fit has been called before,
@@ -4426,7 +4432,10 @@ class TrainablePipeline(PlannedPipeline[TrainableOpType], TrainableOperator):
             # explicitly and do a transform and partial_fit as expected.
             sink_node = self._steps[-1]
             pipeline_prefix = self.remove_last()
+            if not estimator_only and freeze_trained_prefix:
+                pipeline_prefix = pipeline_prefix.freeze_trained()
             trained_pipeline_prefix = pipeline_prefix.convert_to_trained()
+
             transformed_output = trained_pipeline_prefix.transform(X, y)
             if isinstance(transformed_output, tuple):
                 transformed_X, transformed_y = transformed_output
@@ -4807,11 +4816,19 @@ class TrainedPipeline(TrainablePipeline[TrainedOpType], TrainedOperator):
         return cast(TrainedPipeline, result)
 
     def partial_fit(
-        self, X, y=None, unsafe=False, classes=None, **fit_params
+        self,
+        X,
+        y=None,
+        freeze_trained_prefix=True,
+        unsafe=False,
+        classes=None,
+        **fit_params,
     ) -> "TrainedPipeline[TrainedIndividualOp]":
         """partial_fit for a pipeline.
         This method assumes that all but the last node of a pipeline are frozen_trained and
         only the last node needs to be fit using its partial_fit method.
+        If that is not the case, and `freeze_trained_prefix` is True, it freezes the prefix
+        of the pipeline except the last node if they are trained.
 
         Parameters
         ----------
@@ -4819,6 +4836,9 @@ class TrainedPipeline(TrainablePipeline[TrainedOpType], TrainedOperator):
             Features; see partial_fit schema of the last node.
         y:
             Labels/target
+        freeze_trained_prefix:
+            If True, all but the last node are freeze_trained and only
+            the last node is partial_fit.
         unsafe:
             boolean.
             This flag allows users to override the validation that throws an error when the
@@ -4840,25 +4860,27 @@ class TrainedPipeline(TrainablePipeline[TrainedOpType], TrainedOperator):
         for operator in self._steps[:-1]:
             if not operator.is_frozen_trained():
                 estimator_only = False
-        if not estimator_only:
+        if not estimator_only and not freeze_trained_prefix:
             raise ValueError(
                 """partial_fit is only supported on pipelines when all but the last node are frozen_trained and
-        only the last node needs to be fit using its partial_fit method."""
+            only the last node needs to be fit using its partial_fit method. The parameter `freeze_trained_prefix`
+            can be set to True if the prefix is trained and needs to be frozen during partial_fit."""
             )
-
         sink_node = self._steps[-1]
-        self.remove_last(inplace=True)
-        transformed_output = self.transform(X, y)
+        pipeline_prefix = self.remove_last()
+        if not estimator_only and freeze_trained_prefix:
+            pipeline_prefix = pipeline_prefix.freeze_trained()
+        transformed_output = pipeline_prefix.transform(X, y)
         if isinstance(transformed_output, tuple):
             transformed_X, transformed_y = transformed_output
         else:
             transformed_X = transformed_output
             transformed_y = y
         trained_sink_node = sink_node.partial_fit(
-            transformed_X, transformed_y, **fit_params
-        )  # note: no classes being passed here as we assume the trained pipeline is obtained after a call to partial_fit
-        new_pipeline = self >> trained_sink_node
-        return new_pipeline
+            transformed_X, transformed_y, classes=classes, **fit_params
+        )
+        trained_pipeline = pipeline_prefix >> trained_sink_node
+        return trained_pipeline
 
 
 OperatorChoiceType = TypeVar("OperatorChoiceType", bound=Operator, covariant=True)

--- a/test/test_core_pipeline.py
+++ b/test/test_core_pipeline.py
@@ -1102,3 +1102,52 @@ class TestPartialFit(unittest.TestCase):
         self.assertEqual(new_trained_pipeline, new_pipeline._trained)
         _ = new_trained_pipeline.predict(self.X_test)
         new_pipeline.partial_fit(self.X_train, self.y_train, classes=[0, 1, 2])
+
+    def test_call_on_trainable_with_freeze_trained_prefix(self):
+        trainable_pipeline = StandardScaler()
+        trained_pipeline = trainable_pipeline.fit(self.X_train, self.y_train)
+        new_pipeline = trained_pipeline >> SGDClassifier()
+        new_pipeline.partial_fit(self.X_train, self.y_train, classes=[0, 1, 2])
+        new_pipeline.pretty_print()
+        new_trained_pipeline = new_pipeline.partial_fit(
+            self.X_test, self.y_test, classes=[0, 1, 2]
+        )
+        self.assertEqual(new_trained_pipeline, new_pipeline._trained)
+        _ = new_trained_pipeline.predict(self.X_test)
+        new_pipeline.partial_fit(self.X_train, self.y_train, classes=[0, 1, 2])
+
+    def test_call_on_trainable_with_freeze_trained_prefix_false(self):
+        trainable_pipeline = StandardScaler()
+        trained_pipeline = trainable_pipeline.fit(self.X_train, self.y_train)
+        new_pipeline = trained_pipeline >> SGDClassifier()
+        with self.assertRaises(ValueError):
+            new_pipeline.partial_fit(
+                self.X_train,
+                self.y_train,
+                freeze_trained_prefix=False,
+                classes=[0, 1, 2],
+            )
+
+    def test_call_on_trained_with_freeze_trained_prefix(self):
+        trainable_pipeline = StandardScaler() >> SGDClassifier()
+        trained_pipeline = trainable_pipeline.fit(self.X_train, self.y_train)
+        new_pipeline = trained_pipeline
+        new_pipeline.partial_fit(self.X_train, self.y_train, classes=[0, 1, 2])
+        new_pipeline.pretty_print()
+        new_trained_pipeline = new_pipeline.partial_fit(
+            self.X_test, self.y_test, classes=[0, 1, 2]
+        )
+        _ = new_trained_pipeline.predict(self.X_test)
+        new_pipeline.partial_fit(self.X_train, self.y_train, classes=[0, 1, 2])
+
+    def test_call_on_trained_with_freeze_trained_prefix_false(self):
+        trainable_pipeline = StandardScaler() >> SGDClassifier()
+        trained_pipeline = trainable_pipeline.fit(self.X_train, self.y_train)
+        new_pipeline = trained_pipeline
+        with self.assertRaises(ValueError):
+            new_pipeline.partial_fit(
+                self.X_train,
+                self.y_train,
+                freeze_trained_prefix=False,
+                classes=[0, 1, 2],
+            )


### PR DESCRIPTION
This option allows users to call `partial_fit` on a trained pipeline without explicitly freezing the prefix. This PR also makes `partial_fit` on a TrainedPipeline such that it does not mutate the original object. This matches our `fit` implementation.