### PR TITLE
Hide SMAC warning and XGBoost warning. Fix AutoPipeline documentation…

### DIFF
--- a/lale/json_operator.py
+++ b/lale/json_operator.py
@@ -428,7 +428,7 @@ def _op_to_json_rec(
                 jsn["viz_label"] = op._impl.viz_label()
             hyperparams = op.reduced_hyperparams()
             if hyperparams is None:
-                jsn["hyperparams"] = None
+                jsn["hyperparams"] = {} if hasattr(op._impl, "fit") else None
             else:
                 hp_schema = _hparams_schemas_to_props(op.hyperparam_schema())
                 hyperparams = {

--- a/lale/lib/lale/auto_pipeline.py
+++ b/lale/lib/lale/auto_pipeline.py
@@ -408,7 +408,7 @@ For an example, see `demo_auto_pipeline.ipynb`_.
 
 .. _`demo_auto_pipeline.ipynb`: https://nbviewer.jupyter.org/github/IBM/lale/blob/master/examples/demo_auto_pipeline.ipynb
 """,
-    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.lale.auto_pipelines.html",
+    "documentation_url": "https://lale.readthedocs.io/en/latest/modules/lale.lib.lale.auto_pipeline.html",
     "import_from": "lale.lib.lale",
     "type": "object",
     "tags": {"pre": [], "op": ["estimator"], "post": []},

--- a/lale/lib/lale/smac.py
+++ b/lale/lib/lale/smac.py
@@ -15,6 +15,7 @@
 import logging
 import time
 import traceback
+import warnings
 
 import numpy as np
 from sklearn.metrics import check_scoring, log_loss
@@ -36,7 +37,9 @@ from lale.lib.sklearn import LogisticRegression
 
 try:
     # Import ConfigSpace and different types of parameters
-    from smac.configspace import ConfigurationSpace
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        from smac.configspace import ConfigurationSpace
 
     # Import SMAC-utilities
     from smac.facade.smac_facade import SMAC as orig_SMAC
@@ -191,8 +194,6 @@ or with
         return self
 
     def predict(self, X_eval, **predict_params):
-        import warnings
-
         warnings.filterwarnings("ignore")
         trained = self._best_estimator
         if trained is None:

--- a/lale/lib/xgboost/xgb_classifier.py
+++ b/lale/lib/xgboost/xgb_classifier.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -70,7 +71,10 @@ class _XGBClassifierImpl:
         if xgboost.__version__ >= "1.3.0" and "eval_metric" not in fit_params:
             # set eval_metric explicitly to avoid spurious warning
             fit_params = {"eval_metric": "logloss", **fit_params}
-        self._wrapped_model.fit(renamed_X, y, **fit_params)
+        with warnings.catch_warnings():
+            if fit_params.get("use_label_encoder", True):
+                warnings.filterwarnings("ignore", category=UserWarning)
+            self._wrapped_model.fit(renamed_X, y, **fit_params)
         return self
 
     def predict(self, X, **predict_params):


### PR DESCRIPTION
…_url. Add missing empy parentheses in pretty_print.

Signed-off-by: Martin Hirzel <hirzel@gmail.com>