### PR TITLE
Use Iterable from collections.abc

### DIFF
--- a/lale/type_checking.py
+++ b/lale/type_checking.py
@@ -32,7 +32,7 @@ as the right side succeed. This is specified using ``{'laleType': 'Any'}``.
 
 import functools
 import inspect
-from collections import Iterable
+from collections.abc import Iterable
 from typing import Any, Dict, List, Optional, Tuple, overload
 
 import jsonschema


### PR DESCRIPTION
Use `Iterable` from `collections.abc` - importing abstract base classes straight from `collections` is not supported in Python 3.10 and above...

Signed-off-by: DanielRyszkaIBM <daniel.ryszka@pl.ibm.com>