### PR TITLE
Fix schemas for XGBoost >= 1.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,9 @@ jobs:
     - name: Install deps for test_snapml
       if: ${{ matrix.test-case == 'test/test_snapml.py' }}
       run: pip install 'numpy>=1.20.1'
+    - name: Install deps for test_core_pipeline with scipy 1.5.4
+      if: ${{ matrix.test-case == 'test/test_core_pipeline.py' }}
+      run: pip install 'scipy==1.5.4'
     - name: Imbalanced learn version for Python 3.8
       if: ${{ matrix.test-case == 'test/test_interoperability.py' &&  matrix.python-version == 3.8}}
       run: pip install 'imbalanced-learn==0.9.0' 'scikit-learn==1.0.2'

--- a/lale/lib/xgboost/xgb_classifier.py
+++ b/lale/lib/xgboost/xgb_classifier.py
@@ -870,7 +870,7 @@ if xgboost_installed and xgboost.__version__ >= "1.6":
                 {"enum": [None]},
             ],
             "default": None,
-        }
+        },
     )
 
 

--- a/lale/lib/xgboost/xgb_classifier.py
+++ b/lale/lib/xgboost/xgb_classifier.py
@@ -803,6 +803,74 @@ if xgboost_installed and xgboost.__version__ >= "1.6":
             "type": "boolean",
             "default": False,
         },
+        max_leaves={
+            "description": """Maximum number of leaves; 0 indicates no limit.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None], "forOptimizer": False},
+            ],
+            "default": None,
+        },
+        max_bin={
+            "description": """If using histogram-based algorithm, maximum number of bins per feature.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None], "forOptimizer": False},
+            ],
+            "default": None,
+        },
+        grow_policy={
+            "description": """Tree growing policy.
+            0: favor splitting at nodes closest to the node, i.e. grow depth-wise.
+            1: favor splitting at nodes with highest loss change.""",
+            "enum": [0, 1, None],
+            "default": None,
+        },
+        sampling_method={
+            "description": """Sampling method. Used only by gpu_hist tree method.
+            - uniform: select random training instances uniformly.
+            - gradient_based select random training instances with higher probability when the gradient and hessian are larger. (cf. CatBoost)""",
+            "enum": ["uniform", "gadient_based", None],
+            "default": None,
+        },
+        max_cat_to_onehot={
+            "description": """A threshold for deciding whether XGBoost should use
+            one-hot encoding based split for categorical data.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        eval_metric={
+            "description": """Metric used for monitoring the training result and early stopping.""",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "array", "items": {"laleType": "callable"}},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        early_stopping_rounds={
+            "description": """Activates early stopping.
+            Validation metric needs to improve at least once in every early_stopping_rounds round(s)
+            to continue training.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        callbacks={
+            "description": """List of callback functions that are applied at end of each iteration.
+            It is possible to use predefined callbacks by using Callback API.""",
+            "anyOf": [
+                {"type": "array", "items": {"laleType": "callable"}},
+                {"enum": [None]},
+            ],
+            "default": None,
+        }
     )
 
 

--- a/lale/lib/xgboost/xgb_regressor.py
+++ b/lale/lib/xgboost/xgb_regressor.py
@@ -760,4 +760,88 @@ available choices are [cpu_predictor, gpu_predictor].""",
         set_as_available=True,
     )
 
+if xgboost_installed and xgboost.__version__ >= "1.6":
+    # https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
+    XGBRegressor = XGBRegressor.customize_schema(
+        max_leaves={
+            "description": """Maximum number of leaves; 0 indicates no limit.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None], "forOptimizer": False},
+            ],
+            "default": None,
+        },
+        max_bin={
+            "description": """If using histogram-based algorithm, maximum number of bins per feature.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None], "forOptimizer": False},
+            ],
+            "default": None,
+        },
+        grow_policy={
+            "description": """Tree growing policy.
+            0: favor splitting at nodes closest to the node, i.e. grow depth-wise.
+            1: favor splitting at nodes with highest loss change.""",
+            "enum": [0, 1, None],
+            "default": None,
+        },
+        sampling_method={
+            "description": """Sampling method. Used only by gpu_hist tree method.
+            - uniform: select random training instances uniformly.
+            - gradient_based select random training instances with higher probability when the gradient and hessian are larger. (cf. CatBoost)""",
+            "enum": ["uniform", "gadient_based", None],
+            "default": None,
+        },
+        max_cat_to_onehot={
+            "description": """A threshold for deciding whether XGBoost should use
+            one-hot encoding based split for categorical data.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        eval_metric={
+            "description": """Metric used for monitoring the training result and early stopping.""",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "array", "items": {"laleType": "callable"}},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        early_stopping_rounds={
+            "description": """Activates early stopping.
+            Validation metric needs to improve at least once in every early_stopping_rounds round(s)
+            to continue training.""",
+            "anyOf": [
+                {"type": "integer"},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        callbacks={
+            "description": """List of callback functions that are applied at end of each iteration.
+            It is possible to use predefined callbacks by using Callback API.""",
+            "anyOf": [
+                {"type": "array", "items": {"laleType": "callable"}},
+                {"enum": [None]},
+            ],
+            "default": None,
+        },
+        n_jobs={
+            "anyOf": [{"type": "integer"}, {"enum": [None]}],
+            "description": "Number of parallel threads used to run xgboost.  (replaces ``nthread``)",
+            "default": 1,
+        },
+        random_state={
+            "anyOf": [{"type": "integer"}, {"enum": [None]}],
+            "description": "Random number seed.  (replaces seed)",
+            "default": 0,
+        },
+    )
+
+
 lale.docstrings.set_docstrings(XGBRegressor)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ else:
         "jsonschema",
         "jsonsubschema>=0.0.6",
         "scikit-learn",
-        "scipy",
+        "scipy<1.9",
         "pandas",
         "decorator",
         "astunparse",


### PR DESCRIPTION
When trying to use XGBoost estimators from xgboost>=1.6, I've encountered the following issue when trying to import simple initialized estimator usgin `lale.helpers.import_from_sklearn_pipeline`:
- code example:
```
m = XGBRegressor()
m_l = import_from_sklearn_pipeline(m)
...
```
- error encountered:
```
Invalid configuration for XGBRegressor(objective='reg:squarederror', base_score=None, booster=None, callbacks=None, colsample_bylevel=None, colsample_bynode=None, colsample_bytree=None, early_stopping_rounds=None, enable_categorical=False, eval_metric=None, gamma=None, gpu_id=None, grow_policy=None, importance_type=None, interaction_constraints=None, learning_rate=None, max_bin=None, max_cat_to_onehot=None, max_delta_step=None, max_depth=None, max_leaves=None, min_child_weight=None, missing=float('nan'), monotone_constraints=None, n_estimators=100, n_jobs=None, num_parallel_tree=None, predictor=None, random_state=None, reg_alpha=None, reg_lambda=None, sampling_method=None, scale_pos_weight=None, subsample=None, tree_method=None, validate_parameters=None, verbosity=None) due to argument 'callbacks', 'early_stopping_rounds', 'eval_metric', 'grow_policy', 'max_bin', 'max_cat_to_onehot', 'max_leaves', 'sampling_method' were unexpected.
Some possible fixes include:
- remove unknown key s'callbacks', 'early_stopping_rounds', 'eval_metric', 'grow_policy', 'max_bin', 'max_cat_to_onehot', 'max_leaves', 'sampling_method' and set random_state=0, n_jobs=1
```

XGBoost added some new parameters in version 1.6: https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.XGBRegressor


Signed-off-by: DanielRyszkaIBM <daniel.ryszka@pl.ibm.com>

