### PR TITLE
Support scikit learn 1.1 and xgboost 1.6

### DIFF
--- a/lale/lib/sklearn/simple_imputer.py
+++ b/lale/lib/sklearn/simple_imputer.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 import pandas as pd
+import sklearn
 import sklearn.impute
 
 import lale.docstrings

--- a/lale/lib/sklearn/simple_imputer.py
+++ b/lale/lib/sklearn/simple_imputer.py
@@ -95,7 +95,7 @@ _hyperparams_schema = {
                     "description": 'When strategy == "constant", fill_value is used to replace all occurrences of missing_values',
                 },
                 "verbose": {
-                    "anyOf": [{"type": "integer"}, {"type": "string"}],
+                    "type": "integer",
                     "default": 0,
                     "description": "Controls the verbosity of the imputer.",
                 },
@@ -185,5 +185,16 @@ _combined_schemas = {
 
 
 SimpleImputer = lale.operators.make_operator(_SimpleImputerImpl, _combined_schemas)
+
+if sklearn.__version__ >= "1.1":
+    # old: https://scikit-learn.org/1.0/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer
+    # new: https://scikit-learn.org/1.1/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer
+    SimpleImputer = SimpleImputer.customize_schema(
+        verbose={
+            "anyOf": [{"type": "integer"}, {"enum": ["deprecated"]}],
+            "default": "deprecated",
+            "description": "Controls the verbosity of the imputer. Deprecated since version 1.1: The ‘verbose’ parameter was deprecated in version 1.1 and will be removed in 1.3. A warning will always be raised upon the removal of empty columns in the future version.",
+        }
+    )
 
 lale.docstrings.set_docstrings(SimpleImputer)

--- a/lale/lib/sklearn/simple_imputer.py
+++ b/lale/lib/sklearn/simple_imputer.py
@@ -95,7 +95,7 @@ _hyperparams_schema = {
                     "description": 'When strategy == "constant", fill_value is used to replace all occurrences of missing_values',
                 },
                 "verbose": {
-                    "type": "integer",
+                    "anyOf": [{"type": "integer"}, {"type": "string"}],
                     "default": 0,
                     "description": "Controls the verbosity of the imputer.",
                 },

--- a/lale/lib/xgboost/xgb_classifier.py
+++ b/lale/lib/xgboost/xgb_classifier.py
@@ -827,9 +827,9 @@ if xgboost_installed and xgboost.__version__ >= "1.6":
         },
         grow_policy={
             "description": """Tree growing policy.
-            0: favor splitting at nodes closest to the node, i.e. grow depth-wise.
-            1: favor splitting at nodes with highest loss change.""",
-            "enum": [0, 1, None],
+            0 or depthwise: favor splitting at nodes closest to the node, i.e. grow depth-wise.
+            1 or lossguide: favor splitting at nodes with highest loss change.""",
+            "enum": [0, 1, "depthwise", "lossguide", None],
             "default": None,
         },
         sampling_method={

--- a/lale/lib/xgboost/xgb_regressor.py
+++ b/lale/lib/xgboost/xgb_regressor.py
@@ -787,9 +787,9 @@ if xgboost_installed and xgboost.__version__ >= "1.6":
         },
         grow_policy={
             "description": """Tree growing policy.
-            0: favor splitting at nodes closest to the node, i.e. grow depth-wise.
-            1: favor splitting at nodes with highest loss change.""",
-            "enum": [0, 1, None],
+            0 or depthwise: favor splitting at nodes closest to the node, i.e. grow depth-wise.
+            1 or lossguide: favor splitting at nodes with highest loss change.""",
+            "enum": [0, 1, "depthwise", "lossguide", None],
             "default": None,
         },
         sampling_method={


### PR DESCRIPTION
Fix the following two issues when call `import_from_sklearn_pipeline`:

1. scikit learn 1.1.1
```
jsonschema.exceptions.ValidationError: Invalid configuration for SimpleImputer(add_indicator=False, copy=True, fill_value=None, missing_values=float('nan'), strategy='mean', verbose='deprecated') due to invalid value verbose=deprecated.
Some possible fixes include:
- set verbose=0
Schema of argument verbose: {
    "type": "integer",
    "default": 0,
    "description": "Controls the verbosity of the imputer.",
}
Invalid value: deprecated
```

2. xgboost 1.6.2
```
jsonschema.exceptions.ValidationError: Invalid configuration for XGBRegressor(objective='reg:squarederror', base_score=0.5, booster='gbtree', callbacks=None, colsample_bylevel=1, colsample_bynode=1, colsample_bytree=1, early_stopping_rounds=None, enable_categorical=False, eval_metric=None, gamma=0, gpu_id=-1, grow_policy='depthwise', importance_type=None, interaction_constraints='', learning_rate=0.1, max_bin=256, max_cat_to_onehot=4, max_delta_step=0, max_depth=3, max_leaves=0, min_child_weight=1, missing=float('nan'), monotone_constraints='()', n_estimators=100, n_jobs=1, num_parallel_tree=1, predictor='auto', random_state=0, reg_alpha=0, reg_lambda=1, sampling_method='uniform', scale_pos_weight=1, subsample=1, tree_method='exact', validate_parameters=1, verbosity=None) due to invalid value grow_policy=depthwise.
Some possible fixes include:
- set grow_policy=None
Schema of argument grow_policy: {
    "description": "Tree growing policy.\n            0: favor splitting at nodes closest to the node, i.e. grow depth-wise.\n            1: favor splitting at nodes with highest loss change.",
    "enum": [0, 1, None],
    "default": None,
}
Invalid value: depthwise
```