### PR TITLE
Adding py.typed marker to enable MyPy on packages that use Lale.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/IBM/lale",
     python_requires=">=3.6",
+    package_data={"lale": ["py.typed"]},
     packages=find_packages(),
     license="",
     install_requires=install_requires,


### PR DESCRIPTION
Signed-off-by: Martin Hirzel <hirzel@gmail.com>