### PR TITLE
Work-around for calling fit on Project with static coluns after clone.

### DIFF
--- a/lale/operators.py
+++ b/lale/operators.py
@@ -3169,7 +3169,10 @@ class TrainedIndividualOp(TrainableIndividualOp, TrainedOperator):
     def fit(self, X, y=None, **fit_params) -> "TrainedIndividualOp":
         if self.has_method("fit") and not self.is_frozen_trained():
             filtered_fit_params = _fixup_hyperparams_dict(fit_params)
-            return super(TrainedIndividualOp, self).fit(X, y, **filtered_fit_params)
+            try:
+                return super(TrainedIndividualOp, self).fit(X, y, **filtered_fit_params)
+            except AttributeError:
+                return self  # for Project with static columns after clone()
         else:
             return self
 


### PR DESCRIPTION
Otherwise, cannot call fit on a pipeline that contains such a Project operator.

Signed-off-by: Martin Hirzel <hirzel@gmail.com>