### PR TITLE
Generalized ite(cond, v1, v2) function to allow non-constant v1 and v2 and used that to implement the clip option of lale.lib.rasl.MinMaxScaler.

### DIFF
--- a/lale/expressions.py
+++ b/lale/expressions.py
@@ -1,4 +1,4 @@
-# Copyright 2020 IBM Corporation
+# Copyright 2020-2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -514,11 +514,15 @@ def replace(
 
 
 def ite(
-    c: Union[Expr, AstExpr, int, float, bool, str],
-    v1: Union[Expr, AstExpr, int, float, bool, str],
-    v2: Union[Expr, AstExpr, int, float, bool, str],
+    cond: Expr,
+    v1: Union[Expr, int, float, bool, str],
+    v2: Union[Expr, int, float, bool, str],
 ) -> Expr:
-    return _make_call_expr("ite", c, v1, v2)
+    if not isinstance(v1, Expr):
+        v1 = Expr(ast.Constant(value=v1))
+    if not isinstance(v2, Expr):
+        v2 = Expr(ast.Constant(value=v2))
+    return _make_call_expr("ite", cond, v1, v2)
 
 
 def identity(subject: Expr) -> Expr:

--- a/lale/lib/rasl/_eval_pandas_df.py
+++ b/lale/lib/rasl/_eval_pandas_df.py
@@ -124,12 +124,15 @@ def astype(df: Any, call: ast.Call):
 def ite(df: Any, call: ast.Call):
     cond = _eval_ast_expr_pandas_df(df, call.args[0])  # type: ignore
     v1 = _eval_ast_expr_pandas_df(df, call.args[1])  # type: ignore
-    if not isinstance(v1, pd.Series):
-        v1 = pd.Series(v1, index=df.index)
     v2 = _eval_ast_expr_pandas_df(df, call.args[2])  # type: ignore
-    if not isinstance(v2, pd.Series):
-        v2 = pd.Series(v2, index=df.index)
-    return v1.where(cond, v2)
+    if not isinstance(v1, pd.Series):
+        if not isinstance(v2, pd.Series):
+            result = cond.map(lambda b: v1 if b else v2)
+        else:
+            result = pd.Series(v1, index=df.index).where(cond, v2)
+    else:
+        result = v1.where(cond, v2)
+    return result
 
 
 def hash(df: Any, call: ast.Call):

--- a/lale/lib/rasl/_eval_pandas_df.py
+++ b/lale/lib/rasl/_eval_pandas_df.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021-2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -122,10 +122,14 @@ def astype(df: Any, call: ast.Call):
 
 
 def ite(df: Any, call: ast.Call):
-    column_c = _eval_ast_expr_pandas_df(df, call.args[0])  # type: ignore
-    v1 = ast.literal_eval(call.args[1])
-    v2 = ast.literal_eval(call.args[2])
-    return column_c.map(lambda b: v1 if b else v2)
+    cond = _eval_ast_expr_pandas_df(df, call.args[0])  # type: ignore
+    v1 = _eval_ast_expr_pandas_df(df, call.args[1])  # type: ignore
+    if not isinstance(v1, pd.Series):
+        v1 = pd.Series(v1, index=df.index)
+    v2 = _eval_ast_expr_pandas_df(df, call.args[2])  # type: ignore
+    if not isinstance(v2, pd.Series):
+        v2 = pd.Series(v2, index=df.index)
+    return v1.where(cond, v2)
 
 
 def hash(df: Any, call: ast.Call):

--- a/lale/lib/rasl/_eval_pandas_df.py
+++ b/lale/lib/rasl/_eval_pandas_df.py
@@ -123,14 +123,15 @@ def astype(df: Any, call: ast.Call):
 
 def ite(df: Any, call: ast.Call):
     cond = _eval_ast_expr_pandas_df(df, call.args[0])  # type: ignore
+    assert isinstance(cond, pd.Series)
     v1 = _eval_ast_expr_pandas_df(df, call.args[1])  # type: ignore
     v2 = _eval_ast_expr_pandas_df(df, call.args[2])  # type: ignore
     if not isinstance(v1, pd.Series):
-        if not isinstance(v2, pd.Series):
+        if not isinstance(v2, pd.Series):  # two scalars, can avoid broadcast
             result = cond.map(lambda b: v1 if b else v2)
-        else:
-            result = pd.Series(v1, index=df.index).where(cond, v2)
-    else:
+        else:  # pandas will implicitly broadcast v1
+            result = v2.mask(cond, v1)
+    else:  # pandas will implicitly broadcast v2 if it is not a Series
         result = v1.where(cond, v2)
     return result
 

--- a/lale/lib/rasl/_eval_spark_df.py
+++ b/lale/lib/rasl/_eval_spark_df.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021-2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -146,8 +146,8 @@ def astype(call: ast.Call):
 
 def ite(call: ast.Call):
     cond = _eval_ast_expr_spark_df(call.args[0])  # type: ignore
-    v1 = ast.literal_eval(call.args[1])
-    v2 = ast.literal_eval(call.args[2])
+    v1 = _eval_ast_expr_spark_df(call.args[1])  # type: ignore
+    v2 = _eval_ast_expr_spark_df(call.args[2])  # type: ignore
     return spark_when(cond, v1).otherwise(v2)  # type: ignore
 
 

--- a/lale/lib/rasl/min_max_scaler.py
+++ b/lale/lib/rasl/min_max_scaler.py
@@ -121,9 +121,9 @@ class _MinMaxScalerImpl(MonoidableOperator[_MinMaxScalerMonoid]):
             c_scaled = c_std * (range_max - range_min) + range_min
             if clip:
                 c_clipped = ite(
-                    it[c] < range_min,
+                    c_scaled < range_min,
                     range_min,
-                    ite(it[c] > range_max, range_max, it[c]),
+                    ite(c_scaled > range_max, range_max, c_scaled),
                 )
             else:
                 c_clipped = c_scaled

--- a/lale/lib/rasl/min_max_scaler.py
+++ b/lale/lib/rasl/min_max_scaler.py
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2021-2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ except ModuleNotFoundError:
 import lale.docstrings
 import lale.operators
 from lale.datasets.data_schemas import forward_metadata
-from lale.expressions import it
+from lale.expressions import it, ite
 from lale.expressions import max as agg_max
 from lale.expressions import min as agg_min
 from lale.helpers import _is_spark_df
@@ -75,8 +75,6 @@ class _MinMaxScalerImpl(MonoidableOperator[_MinMaxScalerMonoid]):
     def __init__(self, feature_range=(0, 1), *, copy=True, clip=False):
         if not copy:
             raise ValueError("`copy=False` is not supported by this implementation")
-        if clip:
-            raise ValueError("`clip=True` is not supported by this implementation")
         self._hyperparams = {"feature_range": feature_range, "copy": copy, "clip": clip}
 
     def transform(self, X):
@@ -112,6 +110,7 @@ class _MinMaxScalerImpl(MonoidableOperator[_MinMaxScalerMonoid]):
 
     def _build_transformer(self):
         range_min, range_max = self._hyperparams["feature_range"]
+        clip = self._hyperparams["clip"]
         ops = {}
         dmin = self.data_min_
         assert dmin is not None
@@ -120,7 +119,15 @@ class _MinMaxScalerImpl(MonoidableOperator[_MinMaxScalerMonoid]):
         for i, c in enumerate(self.feature_names_in_):
             c_std = (it[c] - dmin[i]) / _handle_zeros_in_scale(dmax[i] - dmin[i])
             c_scaled = c_std * (range_max - range_min) + range_min
-            ops.update({c: c_scaled})
+            if clip:
+                c_clipped = ite(
+                    it[c] < range_min,
+                    range_min,
+                    ite(it[c] > range_max, range_max, it[c]),
+                )
+            else:
+                c_clipped = c_scaled
+            ops.update({c: c_clipped})
         return Map(columns=ops)
 
     def to_monoid(self, v: Tuple[Any, Any]) -> _MinMaxScalerMonoid:
@@ -178,11 +185,11 @@ MinMaxScaler = typing.cast(
             desc="`copy=True` is the only value currently supported by this implementation",
             default=True,
         ),
-        clip=Enum(
-            values=[False],
-            desc="`clip=False` is the only value currently supported by this implementation",
-            default=False,
-        ),
+        clip={
+            "type": "boolean",
+            "description": "Set to True to clip transformed values of held-out data to provided feature range.",
+            "default": False,
+        },
     ),
 )
 

--- a/lale/lib/rasl/min_max_scaler.py
+++ b/lale/lib/rasl/min_max_scaler.py
@@ -194,7 +194,7 @@ MinMaxScaler = typing.cast(
             desc="`copy=True` is the only value currently supported by this implementation",
             default=True,
         ),
-        clip={
+        clip={  # missing from min_max_scaler._hyperparams_schema pre sklearn 0.24
             "type": "boolean",
             "description": "Set to True to clip transformed values of held-out data to provided feature range.",
             "default": False,

--- a/test/test_relational.py
+++ b/test/test_relational.py
@@ -2167,8 +2167,6 @@ class TestMap(unittest.TestCase):
             df = datasets["df_num"]
             transformed_df = pretrained.transform(df)
             df, transformed_df = _ensure_pandas(df), _ensure_pandas(transformed_df)
-            print(f"df\n{df}\n")
-            print(f"transformed_df\n{transformed_df}\n")
             self.assertEqual(transformed_df.shape, (5, 4), tgt)
             self.assertSeriesEqual(df["weight"], transformed_df["weight"], tgt)
             self.assertEqual(transformed_df["w<50"][0], "<50", tgt)

--- a/test/test_relational_sklearn.py
+++ b/test/test_relational_sklearn.py
@@ -200,6 +200,32 @@ class TestMinMaxScaler(unittest.TestCase):
             self.assertAlmostEqual(sk_transformed[20, 1], rasl_transformed.iloc[20, 1])
             self.assertAlmostEqual(sk_transformed[20, 2], rasl_transformed.iloc[20, 2])
 
+    def test_transform_clipped(self):
+        columns = ["Product number", "Quantity", "Retailer code"]
+        pandas_data = self.tgt2datasets["pandas"][0][columns]
+        sk_scaler = SkMinMaxScaler(clip=True)
+        sk_trained = sk_scaler.fit(pandas_data)
+        sk_transformed = sk_trained.transform(pandas_data)
+        rasl_scaler = RaslMinMaxScaler(clip=True)
+        for tgt, go_sales in self.tgt2datasets.items():
+            data = go_sales[0][columns]
+            if tgt == "spark":
+                data = SparkDataFrameWithIndex(data)
+            rasl_trained = rasl_scaler.fit(data)
+            rasl_transformed = rasl_trained.transform(data)
+            if tgt == "spark":
+                self.assertEqual(get_index_name(rasl_transformed), "index")
+            rasl_transformed = _ensure_pandas(rasl_transformed)
+            self.assertAlmostEqual(sk_transformed[0, 0], rasl_transformed.iloc[0, 0])
+            self.assertAlmostEqual(sk_transformed[0, 1], rasl_transformed.iloc[0, 1])
+            self.assertAlmostEqual(sk_transformed[0, 2], rasl_transformed.iloc[0, 2])
+            self.assertAlmostEqual(sk_transformed[10, 0], rasl_transformed.iloc[10, 0])
+            self.assertAlmostEqual(sk_transformed[10, 1], rasl_transformed.iloc[10, 1])
+            self.assertAlmostEqual(sk_transformed[10, 2], rasl_transformed.iloc[10, 2])
+            self.assertAlmostEqual(sk_transformed[20, 0], rasl_transformed.iloc[20, 0])
+            self.assertAlmostEqual(sk_transformed[20, 1], rasl_transformed.iloc[20, 1])
+            self.assertAlmostEqual(sk_transformed[20, 2], rasl_transformed.iloc[20, 2])
+
     def test_zero_scale(self):
         pandas_data = pd.DataFrame({"a": [0.5]})
         sk_scaler = SkMinMaxScaler()

--- a/test/test_relational_sklearn.py
+++ b/test/test_relational_sklearn.py
@@ -154,16 +154,12 @@ class TestMinMaxScaler(unittest.TestCase):
         self.assertDictContainsSubset(sk_params, rasl_params)
 
     def test_error(self):
+        _ = RaslMinMaxScaler(clip=True)  # should raise no error
         with self.assertRaisesRegex(
             jsonschema.ValidationError,
             re.compile(r"MinMaxScaler\(copy=False\)", re.MULTILINE | re.DOTALL),
         ):
             _ = RaslMinMaxScaler(copy=False)
-        with self.assertRaisesRegex(
-            jsonschema.ValidationError,
-            re.compile(r"MinMaxScaler\(clip=True\)", re.MULTILINE | re.DOTALL),
-        ):
-            _ = RaslMinMaxScaler(clip=True)
 
     def test_fit(self):
         columns = ["Product number", "Quantity", "Retailer code"]


### PR DESCRIPTION
Signed-off-by: Martin Hirzel <hirzel@gmail.com>