### PR TITLE
Use a newer version of autoai_libs on pypi for Python 3.9 and 3.10.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,8 @@ jobs:
           ${{ runner.os }}-new3
     - name: Install numpy
       run: pip install -U numpy
-    - name: Install autoai-libs from regular pypi for Python 3.7 and 3.8
-      if: ${{ matrix.python-version == 3.7 || matrix.python-version == 3.8 }}
-      run: pip install autoai-libs>=1.12.6
-    - name: Install autoai-libs from test pypi for Python 3.9 and 3.10
-      if: ${{ matrix.python-version == 3.9 || matrix.python-version == '3.10'}}
-      run: pip install autoai-libs>=1.13.6
+    - name: Install autoai-libs from pypi
+      run: pip install "autoai-libs>=1.12.6"
     - name: Install dependencies
       run: pip install --upgrade --upgrade-strategy eager .[full,test]
     - name: pip list packages
@@ -129,12 +125,8 @@ jobs:
           ${{ runner.os }}-new3
     - name: Install numpy
       run: pip install -U numpy
-    - name: Install autoai-libs from regular pypi for Python 3.7 and 3.8
-      if: ${{ matrix.python-version == 3.7 || matrix.python-version == 3.8 }}
-      run: pip install autoai-libs>=1.12.6
-    - name: Install autoai-libs from test pypi for Python 3.9 and 3.10
-      if: ${{ matrix.python-version == 3.9 || matrix.python-version == '3.10'}}
-      run: pip install autoai-libs>=1.13.6
+    - name: Install autoai-libs from pypi
+      run: pip install "autoai-libs>=1.12.6"
     - name: Install dependencies
       run: pip install --upgrade --upgrade-strategy eager ${{matrix.setup-target}}
     - name: Install deps for test_autoai_output_consumption
@@ -245,12 +237,8 @@ jobs:
           ${{ runner.os }}-new3
     - name: Install numpy
       run: pip install -U numpy
-    - name: Install autoai-libs from regular pypi for Python 3.7 and 3.8
-      if: ${{ matrix.python-version == 3.7 || matrix.python-version == 3.8 }}
-      run: pip install autoai-libs>=1.12.6
-    - name: Install autoai-libs from test pypi for Python 3.9 and 3.10
-      if: ${{ matrix.python-version == 3.9  || matrix.python-version == '3.10'}}
-      run: pip install autoai-libs>=1.13.6
+    - name: Install autoai-libs from pypi
+      run: pip install "autoai-libs>=1.12.6"
     - name: Install dependencies
       run: pip install --upgrade --upgrade-strategy eager ${{matrix.setup-target}}
     - name: Install deps for test_autoai_output_consumption
@@ -375,6 +363,9 @@ jobs:
       run: sudo apt-get install graphviz swig
     - name: Install numpy
       run: pip install -U numpy
+    - name: Install autoai-libs from pypi
+      if: ${{ matrix.category == 'demo_' }}
+      run: pip install "autoai-libs>=1.12.6"
     - name: Install dependencies
       run: pip install --upgrade --upgrade-strategy eager ${{matrix.setup-target}}
     - name: pip list packages


### PR DESCRIPTION
Install autoai_libs when testing the demo notebooks

Signed-off-by: Avi Shinnar <shinnar@us.ibm.com>