### PR TITLE
Simplify/Normalize impl class __init__ methods

### DIFF
--- a/lale/lib/category_encoders/hashing_encoder.py
+++ b/lale/lib/category_encoders/hashing_encoder.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
 
     class _SkHashingEncoder:  # type: ignore
-        def __init__(self, *args, **kargs):
+        def __init__(self, *args, **hyperparams):
             raise ValueError("The package 'category_encoders' is not installed.")
 
         def fit(self, X, y=None):
@@ -129,8 +129,7 @@ _combined_schemas = {
 
 class _HashingEncoderImpl:
     def __init__(self, **hyperparams):
-        self._hyperparams = hyperparams
-        self._wrapped_model = _SkHashingEncoder(**self._hyperparams)
+        self._wrapped_model = _SkHashingEncoder(**hyperparams)
 
     def fit(self, X, y=None):
         self._wrapped_model.fit(X, y)

--- a/lale/lib/imblearn/adasyn.py
+++ b/lale/lib/imblearn/adasyn.py
@@ -36,23 +36,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _ADASYNImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        n_neighbors=5,
-        n_jobs=1,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "n_neighbors": n_neighbors,
-            "n_jobs": n_jobs,
-        }
-        resampler_instance = imblearn.over_sampling.ADASYN(**self._hyperparams)
+
+        resampler_instance = imblearn.over_sampling.ADASYN(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
     def fit(self, X, y=None):

--- a/lale/lib/imblearn/all_knn.py
+++ b/lale/lib/imblearn/all_knn.py
@@ -38,8 +38,8 @@ class _AllKNNImpl(_BaseResamplerImpl):
     def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
-        self._hyperparams = hyperparams
-        resampler_instance = imblearn.under_sampling.AllKNN(**self._hyperparams)
+
+        resampler_instance = imblearn.under_sampling.AllKNN(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/imblearn/borderline_smote.py
+++ b/lale/lib/imblearn/borderline_smote.py
@@ -35,29 +35,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _BorderlineSMOTEImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        k_neighbors=5,
-        n_jobs=1,
-        m_neighbors=10,
-        kind="borderline-1",
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "k_neighbors": k_neighbors,
-            "n_jobs": n_jobs,
-            "m_neighbors": m_neighbors,
-            "kind": kind,
-        }
-
-        resampler_instance = imblearn.over_sampling.BorderlineSMOTE(**self._hyperparams)
+        resampler_instance = imblearn.over_sampling.BorderlineSMOTE(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/imblearn/condensed_nearest_neighbour.py
+++ b/lale/lib/imblearn/condensed_nearest_neighbour.py
@@ -35,28 +35,12 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _CondensedNearestNeighbourImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        n_neighbors=None,
-        n_seeds_S=1,
-        n_jobs=1,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "n_neighbors": n_neighbors,
-            "n_seeds_S": n_seeds_S,
-            "n_jobs": n_jobs,
-        }
-
         resampler_instance = imblearn.under_sampling.CondensedNearestNeighbour(
-            **self._hyperparams
+            **hyperparams
         )
         super().__init__(operator=operator, resampler=resampler_instance)
 

--- a/lale/lib/imblearn/edited_nearest_neighbours.py
+++ b/lale/lib/imblearn/edited_nearest_neighbours.py
@@ -38,9 +38,9 @@ class _EditedNearestNeighboursImpl(_BaseResamplerImpl):
     def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
-        self._hyperparams = hyperparams
+
         resampler_instance = imblearn.under_sampling.EditedNearestNeighbours(
-            **self._hyperparams
+            **hyperparams
         )
         super().__init__(operator=operator, resampler=resampler_instance)
 

--- a/lale/lib/imblearn/instance_hardness_threshold.py
+++ b/lale/lib/imblearn/instance_hardness_threshold.py
@@ -34,28 +34,12 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _InstanceHardnessThresholdImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        estimator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        cv=5,
-        n_jobs=1,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "estimator": estimator,
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "cv": cv,
-            "n_jobs": n_jobs,
-        }
-
         resampler_instance = imblearn.under_sampling.InstanceHardnessThreshold(
-            **self._hyperparams
+            **hyperparams
         )
         super().__init__(operator=operator, resampler=resampler_instance)
 

--- a/lale/lib/imblearn/random_over_sampler.py
+++ b/lale/lib/imblearn/random_over_sampler.py
@@ -33,18 +33,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _RandomOverSamplerImpl(_BaseResamplerImpl):
-    def __init__(self, operator=None, sampling_strategy="auto", random_state=None):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-        }
-
-        resampler_instance = imblearn.over_sampling.RandomOverSampler(
-            **self._hyperparams
-        )
+        resampler_instance = imblearn.over_sampling.RandomOverSampler(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/imblearn/repeated_edited_nearest_neighbours.py
+++ b/lale/lib/imblearn/repeated_edited_nearest_neighbours.py
@@ -38,9 +38,9 @@ class _RepeatedEditedNearestNeighboursImpl(_BaseResamplerImpl):
     def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
-        self._hyperparams = hyperparams
+
         resampler_instance = imblearn.under_sampling.RepeatedEditedNearestNeighbours(
-            **self._hyperparams
+            **hyperparams
         )
         super().__init__(operator=operator, resampler=resampler_instance)
 

--- a/lale/lib/imblearn/smote.py
+++ b/lale/lib/imblearn/smote.py
@@ -35,25 +35,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _SMOTEImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        k_neighbors=5,
-        n_jobs=1,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "k_neighbors": k_neighbors,
-            "n_jobs": n_jobs,
-        }
-
-        resampler_instance = imblearn.over_sampling.SMOTE(**self._hyperparams)
+        resampler_instance = imblearn.over_sampling.SMOTE(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/imblearn/smoteenn.py
+++ b/lale/lib/imblearn/smoteenn.py
@@ -33,25 +33,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _SMOTEENNImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        smote=None,
-        enn=None,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "smote": smote,
-            "enn": enn,
-        }
-
-        resampler_instance = imblearn.combine.SMOTEENN(**self._hyperparams)
+        resampler_instance = imblearn.combine.SMOTEENN(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/imblearn/smoten.py
+++ b/lale/lib/imblearn/smoten.py
@@ -35,24 +35,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _SMOTENImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        *,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        k_neighbors=5,
-        n_jobs=1,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "k_neighbors": k_neighbors,
-            "n_jobs": n_jobs,
-        }
-        resampler_instance = imblearn.over_sampling.SMOTEN(**self._hyperparams)
+
+        resampler_instance = imblearn.over_sampling.SMOTEN(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/imblearn/smotenc.py
+++ b/lale/lib/imblearn/smotenc.py
@@ -36,25 +36,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _SMOTENCImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        *,
-        operator=None,
-        categorical_features=None,
-        sampling_strategy="auto",
-        random_state=None,
-        k_neighbors=5,
-        n_jobs=1,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "categorical_features": categorical_features,
-            "random_state": random_state,
-            "k_neighbors": k_neighbors,
-            "n_jobs": n_jobs,
-        }
+        self._hyperparams = hyperparams
+
         super().__init__(operator=operator, resampler=None)
 
     def fit(self, X, y=None):

--- a/lale/lib/imblearn/svm_smote.py
+++ b/lale/lib/imblearn/svm_smote.py
@@ -35,31 +35,11 @@ from .base_resampler import _BaseResamplerImpl
 
 
 class _SVMSMOTEImpl(_BaseResamplerImpl):
-    def __init__(
-        self,
-        operator=None,
-        sampling_strategy="auto",
-        random_state=None,
-        k_neighbors=5,
-        n_jobs=1,
-        m_neighbors=10,
-        svm_estimator=None,
-        out_step=0.5,
-    ):
+    def __init__(self, operator=None, **hyperparams):
         if operator is None:
             raise ValueError("Operator is a required argument.")
 
-        self._hyperparams = {
-            "sampling_strategy": sampling_strategy,
-            "random_state": random_state,
-            "k_neighbors": k_neighbors,
-            "n_jobs": n_jobs,
-            "m_neighbors": m_neighbors,
-            "svm_estimator": svm_estimator,
-            "out_step": out_step,
-        }
-
-        resampler_instance = imblearn.over_sampling.SVMSMOTE(**self._hyperparams)
+        resampler_instance = imblearn.over_sampling.SVMSMOTE(**hyperparams)
         super().__init__(operator=operator, resampler=resampler_instance)
 
 

--- a/lale/lib/lightgbm/lgbm_classifier.py
+++ b/lale/lib/lightgbm/lgbm_classifier.py
@@ -30,56 +30,14 @@ except ImportError:
 
 
 class _LGBMClassifierImpl:
-    def __init__(
-        self,
-        boosting_type="gbdt",
-        num_leaves=31,
-        max_depth=-1,
-        learning_rate=0.1,
-        n_estimators=100,
-        subsample_for_bin=200000,
-        objective=None,
-        class_weight=None,
-        min_split_gain=0.0,
-        min_child_weight=0.001,
-        min_child_samples=20,
-        subsample=1.0,
-        subsample_freq=0,
-        colsample_bytree=1.0,
-        reg_alpha=0.0,
-        reg_lambda=0.0,
-        random_state=None,
-        n_jobs=-1,
-        silent=True,
-        importance_type="split",
-    ):
+    def __init__(self, **hyperparams):
         assert lightgbm_installed, """Your Python environment does not have lightgbm installed. You can install it with
     pip install lightgbm
 or with
     pip install 'lale[full]'"""
-        self._hyperparams = {
-            "boosting_type": boosting_type,
-            "num_leaves": num_leaves,
-            "max_depth": max_depth,
-            "learning_rate": learning_rate,
-            "n_estimators": n_estimators,
-            "subsample_for_bin": subsample_for_bin,
-            "objective": objective,
-            "class_weight": class_weight,
-            "min_split_gain": min_split_gain,
-            "min_child_weight": min_child_weight,
-            "min_child_samples": min_child_samples,
-            "subsample": subsample,
-            "subsample_freq": subsample_freq,
-            "colsample_bytree": colsample_bytree,
-            "reg_alpha": reg_alpha,
-            "reg_lambda": reg_lambda,
-            "random_state": random_state,
-            "n_jobs": n_jobs,
-            "silent": silent,
-            "importance_type": importance_type,
-        }
-        self._wrapped_model = lightgbm.sklearn.LGBMClassifier(**self._hyperparams)
+        self._hyperparams = hyperparams
+
+        self._wrapped_model = lightgbm.sklearn.LGBMClassifier(**hyperparams)
 
     def fit(self, X, y=None, **fit_params):
         if X.shape[0] * self._wrapped_model.subsample < 1.0:

--- a/lale/lib/lightgbm/lgbm_regressor.py
+++ b/lale/lib/lightgbm/lgbm_regressor.py
@@ -30,55 +30,13 @@ except ImportError:
 
 
 class _LGBMRegressorImpl:
-    def __init__(
-        self,
-        boosting_type="gbdt",
-        num_leaves=31,
-        max_depth=-1,
-        learning_rate=0.1,
-        n_estimators=100,
-        subsample_for_bin=200000,
-        objective=None,
-        class_weight=None,
-        min_split_gain=0.0,
-        min_child_weight=0.001,
-        min_child_samples=20,
-        subsample=1.0,
-        subsample_freq=0,
-        colsample_bytree=1.0,
-        reg_alpha=0.0,
-        reg_lambda=0.0,
-        random_state=None,
-        n_jobs=-1,
-        silent=True,
-        importance_type="split",
-    ):
+    def __init__(self, **hyperparams):
         assert lightgbm_installed, """Your Python environment does not have lightgbm installed. You can install it with
     pip install lightgbm
 or with
     pip install 'lale[full]'"""
-        self._hyperparams = {
-            "boosting_type": boosting_type,
-            "num_leaves": num_leaves,
-            "max_depth": max_depth,
-            "learning_rate": learning_rate,
-            "n_estimators": n_estimators,
-            "subsample_for_bin": subsample_for_bin,
-            "objective": objective,
-            "class_weight": class_weight,
-            "min_split_gain": min_split_gain,
-            "min_child_weight": min_child_weight,
-            "min_child_samples": min_child_samples,
-            "subsample": subsample,
-            "subsample_freq": subsample_freq,
-            "colsample_bytree": colsample_bytree,
-            "reg_alpha": reg_alpha,
-            "reg_lambda": reg_lambda,
-            "random_state": random_state,
-            "n_jobs": n_jobs,
-            "silent": silent,
-            "importance_type": importance_type,
-        }
+        self._hyperparams = hyperparams
+
         self._wrapped_model = lightgbm.sklearn.LGBMRegressor(**self._hyperparams)
 
     def fit(self, X, y=None, **fit_params):

--- a/lale/lib/sklearn/logistic_regression.py
+++ b/lale/lib/sklearn/logistic_regression.py
@@ -424,10 +424,7 @@ _combined_schemas = {
 
 class _LogisticRegressionImpl:
     def __init__(self, **hyperparams):
-        self._hyperparams = hyperparams
-        self._wrapped_model = sklearn.linear_model.LogisticRegression(
-            **self._hyperparams
-        )
+        self._wrapped_model = sklearn.linear_model.LogisticRegression(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         try:

--- a/lale/lib/sklearn/one_hot_encoder.py
+++ b/lale/lib/sklearn/one_hot_encoder.py
@@ -139,8 +139,7 @@ _combined_schemas = {
 
 class _OneHotEncoderImpl:
     def __init__(self, **hyperparams):
-        self._hyperparams = hyperparams
-        self._wrapped_model = sklearn.preprocessing.OneHotEncoder(**self._hyperparams)
+        self._wrapped_model = sklearn.preprocessing.OneHotEncoder(**hyperparams)
 
     def fit(self, X, y=None):
         self._wrapped_model.fit(X, y)

--- a/lale/lib/sklearn/select_k_best.py
+++ b/lale/lib/sklearn/select_k_best.py
@@ -20,12 +20,10 @@ import lale.operators
 
 
 class _SelectKBestImpl:
-    def __init__(self, score_func=None, k=10):
-        if score_func:
-            self._hyperparams = {"score_func": score_func, "k": k}
-        else:
-            self._hyperparams = {"k": k}
-        self._wrapped_model = sklearn.feature_selection.SelectKBest(**self._hyperparams)
+    def __init__(self, **hyperparams):
+        if hyperparams["score_func"] is None:
+            del hyperparams["score_func"]
+        self._wrapped_model = sklearn.feature_selection.SelectKBest(**hyperparams)
 
     def fit(self, X, y=None):
         self._wrapped_model.fit(X, y)

--- a/lale/lib/sklearn/simple_imputer.py
+++ b/lale/lib/sklearn/simple_imputer.py
@@ -24,24 +24,8 @@ import lale.operators
 
 
 class _SimpleImputerImpl:
-    def __init__(
-        self,
-        missing_values=None,
-        strategy="mean",
-        fill_value=None,
-        verbose=0,
-        copy=True,
-        add_indicator=False,
-    ):
-        self._hyperparams = {
-            "missing_values": missing_values,
-            "strategy": strategy,
-            "fill_value": fill_value,
-            "verbose": verbose,
-            "copy": copy,
-            "add_indicator": add_indicator,
-        }
-        self._wrapped_model = sklearn.impute.SimpleImputer(**self._hyperparams)
+    def __init__(self, **hyperparams):
+        self._wrapped_model = sklearn.impute.SimpleImputer(**hyperparams)
 
     def fit(self, X, y=None):
         self._wrapped_model.fit(X, y)

--- a/lale/lib/sklearn/tfidf_vectorizer.py
+++ b/lale/lib/sklearn/tfidf_vectorizer.py
@@ -24,9 +24,8 @@ class _TfidfVectorizerImpl:
     def __init__(self, **hyperparams):
         if "dtype" in hyperparams and hyperparams["dtype"] == "float64":
             hyperparams = {**hyperparams, "dtype": np.float64}
-        self._hyperparams = hyperparams
         self._wrapped_model = sklearn.feature_extraction.text.TfidfVectorizer(
-            **self._hyperparams
+            **hyperparams
         )
 
     def fit(self, X, y=None):

--- a/lale/lib/snapml/batched_tree_ensemble_classifier.py
+++ b/lale/lib/snapml/batched_tree_ensemble_classifier.py
@@ -32,27 +32,15 @@ def _ensure_numpy(data):
 
 
 class _BatchedTreeEnsembleClassifierImpl:
-    def __init__(
-        self,
-        base_ensemble=None,
-        max_sub_ensembles=10,
-        inner_lr_scaling=0.5,
-        outer_lr_scaling=0.5,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        if base_ensemble is None:
+        if hyperparams.get("base_ensemble", None) is None:
             from snapml import SnapBoostingMachineClassifier
 
-            base_ensemble = SnapBoostingMachineClassifier()
-        self._hyperparams = {
-            "base_ensemble": base_ensemble,
-            "max_sub_ensembles": max_sub_ensembles,
-            "inner_lr_scaling": inner_lr_scaling,
-            "outer_lr_scaling": outer_lr_scaling,
-        }
-        self._wrapped_model = snapml.BatchedTreeEnsembleClassifier(**self._hyperparams)
+            hyperparams["base_ensemble"] = SnapBoostingMachineClassifier()
+        self._wrapped_model = snapml.BatchedTreeEnsembleClassifier(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = _ensure_numpy(X)

--- a/lale/lib/snapml/batched_tree_ensemble_regressor.py
+++ b/lale/lib/snapml/batched_tree_ensemble_regressor.py
@@ -32,27 +32,15 @@ def _ensure_numpy(data):
 
 
 class _BatchedTreeEnsembleRegressorImpl:
-    def __init__(
-        self,
-        base_ensemble=None,
-        max_sub_ensembles=10,
-        inner_lr_scaling=0.5,
-        outer_lr_scaling=0.5,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        if base_ensemble is None:
+        if hyperparams.get("base_ensemble") is None:
             from snapml import SnapBoostingMachineRegressor
 
-            base_ensemble = SnapBoostingMachineRegressor()
-        self._hyperparams = {
-            "base_ensemble": base_ensemble,
-            "max_sub_ensembles": max_sub_ensembles,
-            "inner_lr_scaling": inner_lr_scaling,
-            "outer_lr_scaling": outer_lr_scaling,
-        }
-        self._wrapped_model = snapml.BatchedTreeEnsembleRegressor(**self._hyperparams)
+            hyperparams["base_ensemble"] = SnapBoostingMachineRegressor()
+        self._wrapped_model = snapml.BatchedTreeEnsembleRegressor(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = _ensure_numpy(X)

--- a/lale/lib/snapml/snap_boosting_machine_classifier.py
+++ b/lale/lib/snapml/snap_boosting_machine_classifier.py
@@ -28,71 +28,18 @@ import lale.operators
 
 
 class _SnapBoostingMachineClassifierImpl:
-    def __init__(
-        self,
-        num_round=100,
-        learning_rate=0.1,
-        random_state=0,
-        colsample_bytree=1.0,
-        subsample=1.0,
-        verbose=False,
-        lambda_l2=0.0,
-        early_stopping_rounds=10,
-        compress_trees=False,
-        base_score=None,
-        class_weight=None,
-        max_depth=None,
-        min_max_depth=1,
-        max_max_depth=5,
-        n_jobs=1,
-        use_histograms=True,
-        hist_nbins=256,
-        use_gpu=False,
-        gpu_id=0,
-        tree_select_probability=1.0,
-        regularizer=1.0,
-        fit_intercept=False,
-        gamma=1.0,
-        n_components=10,
-        gpu_ids=None,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_version is not None
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "num_round": num_round,
-            "learning_rate": learning_rate,
-            "random_state": random_state,
-            "colsample_bytree": colsample_bytree,
-            "subsample": subsample,
-            "verbose": verbose,
-            "lambda_l2": lambda_l2,
-            "early_stopping_rounds": early_stopping_rounds,
-            "compress_trees": compress_trees,
-            "base_score": base_score,
-            "class_weight": class_weight,
-            "max_depth": max_depth,
-            "min_max_depth": min_max_depth,
-            "max_max_depth": max_max_depth,
-            "n_jobs": n_jobs,
-            "use_histograms": use_histograms,
-            "hist_nbins": hist_nbins,
-            "use_gpu": use_gpu,
-            "tree_select_probability": tree_select_probability,
-            "regularizer": regularizer,
-            "fit_intercept": fit_intercept,
-            "gamma": gamma,
-            "n_components": n_components,
-        }
-        if snapml_version > version.Version("1.7.8"):
-            if gpu_ids is None:
-                self._hyperparams["gpu_ids"] = [0]
-            else:
-                self._hyperparams["gpu_ids"] = gpu_ids
-        else:
-            self._hyperparams["gpu_id"] = gpu_id
 
-        self._wrapped_model = snapml.SnapBoostingMachineClassifier(**self._hyperparams)
+        if (
+            snapml_version > version.Version("1.7.8")
+            and hyperparams.get("gpu_ids", None) is None
+        ):
+            hyperparams["gpu_ids"] = [0]
+
+        self._wrapped_model = snapml.SnapBoostingMachineClassifier(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_boosting_machine_regressor.py
+++ b/lale/lib/snapml/snap_boosting_machine_regressor.py
@@ -24,63 +24,12 @@ import lale.operators
 
 
 class _SnapBoostingMachineRegressorImpl:
-    def __init__(
-        self,
-        num_round=100,
-        objective="mse",
-        learning_rate=0.1,
-        random_state=0,
-        colsample_bytree=1.0,
-        subsample=1.0,
-        verbose=False,
-        lambda_l2=0.0,
-        early_stopping_rounds=10,
-        compress_trees=False,
-        base_score=None,
-        max_depth=None,
-        min_max_depth=1,
-        max_max_depth=5,
-        n_jobs=1,
-        use_histograms=True,
-        hist_nbins=256,
-        use_gpu=False,
-        gpu_id=0,
-        tree_select_probability=1.0,
-        regularizer=1.0,
-        fit_intercept=False,
-        gamma=1.0,
-        n_components=10,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "num_round": num_round,
-            "objective": objective,
-            "learning_rate": learning_rate,
-            "random_state": random_state,
-            "colsample_bytree": colsample_bytree,
-            "subsample": subsample,
-            "verbose": verbose,
-            "lambda_l2": lambda_l2,
-            "early_stopping_rounds": early_stopping_rounds,
-            "compress_trees": compress_trees,
-            "base_score": base_score,
-            "max_depth": max_depth,
-            "min_max_depth": min_max_depth,
-            "max_max_depth": max_max_depth,
-            "n_jobs": n_jobs,
-            "use_histograms": use_histograms,
-            "hist_nbins": hist_nbins,
-            "use_gpu": use_gpu,
-            "gpu_id": gpu_id,
-            "tree_select_probability": tree_select_probability,
-            "regularizer": regularizer,
-            "fit_intercept": fit_intercept,
-            "gamma": gamma,
-            "n_components": n_components,
-        }
-        self._wrapped_model = snapml.SnapBoostingMachineRegressor(**self._hyperparams)
+
+        self._wrapped_model = snapml.SnapBoostingMachineRegressor(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_decision_tree_classifier.py
+++ b/lale/lib/snapml/snap_decision_tree_classifier.py
@@ -24,39 +24,12 @@ import lale.operators
 
 
 class _SnapDecisionTreeClassifierImpl:
-    def __init__(
-        self,
-        criterion="gini",
-        splitter="best",
-        max_depth=None,
-        min_samples_leaf=1,
-        max_features=None,
-        random_state=None,
-        n_jobs=1,
-        use_histograms=True,
-        hist_nbins=256,
-        use_gpu=False,
-        gpu_id=0,
-        verbose=False,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "criterion": criterion,
-            "splitter": splitter,
-            "max_depth": max_depth,
-            "min_samples_leaf": min_samples_leaf,
-            "max_features": max_features,
-            "random_state": random_state,
-            "n_jobs": n_jobs,
-            "use_histograms": use_histograms,
-            "hist_nbins": hist_nbins,
-            "use_gpu": use_gpu,
-            "gpu_id": gpu_id,
-            "verbose": verbose,
-        }
-        self._wrapped_model = snapml.SnapDecisionTreeClassifier(**self._hyperparams)
+
+        self._wrapped_model = snapml.SnapDecisionTreeClassifier(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_decision_tree_regressor.py
+++ b/lale/lib/snapml/snap_decision_tree_regressor.py
@@ -24,39 +24,12 @@ import lale.operators
 
 
 class _SnapDecisionTreeRegressorImpl:
-    def __init__(
-        self,
-        criterion="mse",
-        splitter="best",
-        max_depth=None,
-        min_samples_leaf=1,
-        max_features=None,
-        random_state=None,
-        n_jobs=1,
-        use_histograms=True,
-        hist_nbins=256,
-        use_gpu=False,
-        gpu_id=0,
-        verbose=False,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "criterion": criterion,
-            "splitter": splitter,
-            "max_depth": max_depth,
-            "min_samples_leaf": min_samples_leaf,
-            "max_features": max_features,
-            "random_state": random_state,
-            "n_jobs": n_jobs,
-            "use_histograms": use_histograms,
-            "hist_nbins": hist_nbins,
-            "use_gpu": use_gpu,
-            "gpu_id": gpu_id,
-            "verbose": verbose,
-        }
-        self._wrapped_model = snapml.SnapDecisionTreeRegressor(**self._hyperparams)
+
+        self._wrapped_model = snapml.SnapDecisionTreeRegressor(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_linear_regression.py
+++ b/lale/lib/snapml/snap_linear_regression.py
@@ -24,62 +24,15 @@ import lale.operators
 
 
 class _SnapLinearRegressionImpl:
-    def __init__(
-        self,
-        max_iter=1000,
-        regularizer=1.0,
-        use_gpu=False,
-        device_ids=None,
-        dual=True,
-        verbose=False,
-        n_jobs=1,
-        penalty="l2",
-        tol=0.001,
-        generate_training_history=None,
-        privacy=False,
-        eta=0.3,
-        batch_size=100,
-        privacy_epsilon=10,
-        grad_clip=1,
-        fit_intercept=False,
-        intercept_scaling=1.0,
-        normalize=False,
-        kernel="linear",
-        gamma=1.0,
-        n_components=100,
-        random_state=None,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "max_iter": max_iter,
-            "regularizer": regularizer,
-            "use_gpu": use_gpu,
-            "device_ids": device_ids,
-            "dual": dual,
-            "verbose": verbose,
-            "n_jobs": n_jobs,
-            "penalty": penalty,
-            "tol": tol,
-            "generate_training_history": generate_training_history,
-            "privacy": privacy,
-            "eta": eta,
-            "batch_size": batch_size,
-            "privacy_epsilon": privacy_epsilon,
-            "grad_clip": grad_clip,
-            "fit_intercept": fit_intercept,
-            "intercept_scaling": intercept_scaling,
-            "normalize": normalize,
-            "kernel": kernel,
-            "gamma": gamma,
-            "n_components": n_components,
-            "random_state": random_state,
-        }
-        modified_hps = {**self._hyperparams}
-        if modified_hps["device_ids"] is None:
-            modified_hps["device_ids"] = []  # TODO: support list as default
-        self._wrapped_model = snapml.LinearRegression(**modified_hps)
+
+        if hyperparams.get("device_ids", None) is None:
+            hyperparams["device_ids"] = []
+
+        self._wrapped_model = snapml.LinearRegression(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_logistic_regression.py
+++ b/lale/lib/snapml/snap_logistic_regression.py
@@ -24,65 +24,16 @@ import lale.operators
 
 
 class _SnapLogisticRegressionImpl:
-    def __init__(
-        self,
-        max_iter=1000,
-        regularizer=1.0,
-        device_ids=None,
-        verbose=False,
-        use_gpu=False,
-        class_weight=None,
-        dual=True,
-        n_jobs=1,
-        penalty="l2",
-        tol=0.001,
-        generate_training_history=None,
-        privacy=False,
-        eta=0.3,
-        batch_size=100,
-        privacy_epsilon=10,
-        grad_clip=1,
-        fit_intercept=False,
-        intercept_scaling=1.0,
-        normalize=False,
-        kernel=None,
-        gamma=1.0,
-        n_components=100,
-        random_state=None,
-    ):
+    def __init__(self, **hyperparams):
 
         assert (
             snapml_installed
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "max_iter": max_iter,
-            "regularizer": regularizer,
-            "device_ids": device_ids,
-            "verbose": verbose,
-            "use_gpu": use_gpu,
-            "class_weight": class_weight,
-            "dual": dual,
-            "n_jobs": n_jobs,
-            "penalty": penalty,
-            "tol": tol,
-            "generate_training_history": generate_training_history,
-            "privacy": privacy,
-            "eta": eta,
-            "batch_size": batch_size,
-            "privacy_epsilon": privacy_epsilon,
-            "grad_clip": grad_clip,
-            "fit_intercept": fit_intercept,
-            "intercept_scaling": intercept_scaling,
-            "normalize": normalize,
-            "kernel": kernel,
-            "gamma": gamma,
-            "n_components": n_components,
-            "random_state": random_state,
-        }
-        modified_hps = {**self._hyperparams}
-        if modified_hps["device_ids"] is None:
-            modified_hps["device_ids"] = [0]  # TODO: support list as default
-        self._wrapped_model = snapml.SnapLogisticRegression(**modified_hps)
+
+        if hyperparams.get("device_ids", None) is None:
+            hyperparams["device_ids"] = []
+
+        self._wrapped_model = snapml.SnapLogisticRegression(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_random_forest_classifier.py
+++ b/lale/lib/snapml/snap_random_forest_classifier.py
@@ -26,47 +26,20 @@ import lale.operators
 
 
 class _SnapRandomForestClassifierImpl:
-    def __init__(
-        self,
-        n_estimators=10,
-        criterion="gini",
-        max_depth=None,
-        min_samples_leaf=1,
-        max_features="auto",
-        bootstrap=True,
-        n_jobs=1,
-        random_state=None,
-        verbose=False,
-        use_histograms=False,
-        hist_nbins=256,
-        use_gpu=False,
-        gpu_ids=None,
-        compress_trees=False,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_version is not None
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "n_estimators": n_estimators,
-            "criterion": criterion,
-            "max_depth": max_depth,
-            "min_samples_leaf": min_samples_leaf,
-            "max_features": max_features,
-            "bootstrap": bootstrap,
-            "n_jobs": n_jobs,
-            "random_state": random_state,
-            "verbose": verbose,
-            "use_histograms": use_histograms,
-            "hist_nbins": hist_nbins,
-            "use_gpu": use_gpu,
-            "gpu_ids": gpu_ids,
-        }
-        if snapml_version > version.Version("1.7.8"):
-            self._hyperparams["compress_trees"] = compress_trees
-        modified_hps = {**self._hyperparams}
-        if modified_hps["gpu_ids"] is None:
-            modified_hps["gpu_ids"] = [0]  # TODO: support list as default
-        self._wrapped_model = snapml.SnapRandomForestClassifier(**modified_hps)
+
+        if (
+            snapml_version <= version.Version("1.7.8")
+            and "compress_trees" in hyperparams
+        ):
+            del hyperparams["compress_trees"]
+        if hyperparams.get("gpu_ids", None) is None:
+            hyperparams["gpu_ids"] = [0]
+
+        self._wrapped_model = snapml.SnapRandomForestClassifier(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_random_forest_regressor.py
+++ b/lale/lib/snapml/snap_random_forest_regressor.py
@@ -26,48 +26,20 @@ import lale.operators
 
 
 class _SnapRandomForestRegressorImpl:
-    def __init__(
-        self,
-        n_estimators=10,
-        criterion="mse",
-        max_depth=None,
-        min_samples_leaf=1,
-        max_features="auto",
-        bootstrap=True,
-        n_jobs=None,
-        random_state=None,
-        verbose=False,
-        use_histograms=False,
-        hist_nbins=256,
-        use_gpu=False,
-        gpu_ids=None,
-        compress_trees=False,
-    ):
+    def __init__(self, **hyperparams):
         assert (
             snapml_version is not None
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "n_estimators": n_estimators,
-            "criterion": criterion,
-            "max_depth": max_depth,
-            "min_samples_leaf": min_samples_leaf,
-            "max_features": max_features,
-            "bootstrap": bootstrap,
-            "n_jobs": n_jobs,
-            "random_state": random_state,
-            "verbose": verbose,
-            "use_histograms": use_histograms,
-            "hist_nbins": hist_nbins,
-            "use_gpu": use_gpu,
-            "gpu_ids": gpu_ids,
-        }
-        if snapml_version > version.Version("1.7.8"):
-            self._hyperparams["compress_trees"] = compress_trees
 
-        modified_hps = {**self._hyperparams}
-        if modified_hps["gpu_ids"] is None:
-            modified_hps["gpu_ids"] = [0]  # TODO: support list as default
-        self._wrapped_model = snapml.SnapRandomForestRegressor(**modified_hps)
+        if (
+            snapml_version <= version.Version("1.7.8")
+            and "compress_trees" in hyperparams
+        ):
+            del hyperparams["compress_trees"]
+        if hyperparams.get("gpu_ids", None) is None:
+            hyperparams["gpu_ids"] = [0]
+
+        self._wrapped_model = snapml.SnapRandomForestRegressor(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/snapml/snap_svm_classifier.py
+++ b/lale/lib/snapml/snap_svm_classifier.py
@@ -27,54 +27,19 @@ import lale.operators
 
 
 class _SnapSVMClassifierImpl:
-    def __init__(
-        self,
-        max_iter=1000,
-        regularizer=1.0,
-        device_ids=None,
-        verbose=False,
-        use_gpu=False,
-        class_weight=None,
-        n_jobs=1,
-        tol=0.001,
-        generate_training_history=None,
-        fit_intercept=False,
-        intercept_scaling=1.0,
-        normalize=False,
-        kernel=None,
-        gamma=1.0,
-        n_components=100,
-        random_state=None,
-        loss="hinge",
-    ):
+    def __init__(self, **hyperparams):
 
         assert (
             snapml_version is not None
         ), """Your Python environment does not have snapml installed. Install using: pip install snapml"""
-        self._hyperparams = {
-            "max_iter": max_iter,
-            "regularizer": regularizer,
-            "device_ids": device_ids,
-            "verbose": verbose,
-            "use_gpu": use_gpu,
-            "class_weight": class_weight,
-            "n_jobs": n_jobs,
-            "tol": tol,
-            "generate_training_history": generate_training_history,
-            "fit_intercept": fit_intercept,
-            "intercept_scaling": intercept_scaling,
-            "normalize": normalize,
-            "kernel": kernel,
-            "gamma": gamma,
-            "n_components": n_components,
-            "random_state": random_state,
-        }
-        if snapml_version > version.Version("1.8.0"):
-            self._hyperparams["loss"] = loss
-        modified_hps = {**self._hyperparams}
-        if modified_hps["device_ids"] is None:
-            modified_hps["device_ids"] = [0]  # TODO: support list as default
-        self._wrapped_model = snapml.SnapSVMClassifier(**modified_hps)
+
+        if snapml_version <= version.Version("1.8.0") and "loss" in hyperparams:
+            del hyperparams["loss"]
+
+        if hyperparams.get("device_ids", None) is None:
+            hyperparams["device_ids"] = [0]
+
+        self._wrapped_model = snapml.SnapSVMClassifier(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         X = lale.datasets.data_schemas.strip_schema(X)

--- a/lale/lib/xgboost/xgb_classifier.py
+++ b/lale/lib/xgboost/xgb_classifier.py
@@ -71,8 +71,7 @@ class _XGBClassifierImpl:
 
     def __init__(self, **hyperparams):
         self.validate_hyperparams(**hyperparams)
-        self._hyperparams = hyperparams
-        self._wrapped_model = xgboost.XGBClassifier(**self._hyperparams)
+        self._wrapped_model = xgboost.XGBClassifier(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         renamed_X = _rename_all_features(X)

--- a/lale/lib/xgboost/xgb_regressor.py
+++ b/lale/lib/xgboost/xgb_regressor.py
@@ -68,8 +68,7 @@ class _XGBRegressorImpl:
 
     def __init__(self, **hyperparams):
         self.validate_hyperparams(**hyperparams)
-        self._hyperparams = hyperparams
-        self._wrapped_model = xgboost.XGBRegressor(**self._hyperparams)
+        self._wrapped_model = xgboost.XGBRegressor(**hyperparams)
 
     def fit(self, X, y, **fit_params):
         renamed_X = _rename_all_features(X)


### PR DESCRIPTION
- Remove unneeded arguments to impl classes, replacing them with **hyperparams.
- Stop saving self._hyperparams unless nedded

Signed-off-by: Avi Shinnar <shinnar@us.ibm.com>