### PR TITLE
Miscellaneous minor fixes in lale.lib.aif360 and lale.lib.imblearn.

### DIFF
--- a/lale/lib/aif360/adversarial_debiasing.py
+++ b/lale/lib/aif360/adversarial_debiasing.py
@@ -14,9 +14,9 @@
 
 import contextlib
 import io
+import os
 import uuid
 
-import aif360.algorithms.inprocessing
 import packaging.version
 
 import lale.docstrings
@@ -31,6 +31,12 @@ from .util import (
     _categorical_output_predict_schema,
     _categorical_supervised_input_fit_schema,
 )
+
+# suppress spurious warnings from TensorFlow that are caused by
+# indirectly importing it via aif360.algorithms.inprocessing
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+import aif360.algorithms.inprocessing  # noqa:E402 # pylint:disable=wrong-import-position,wrong-import-order
 
 try:
     import tensorflow as tf

--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -528,8 +528,9 @@ class _BasePostEstimatorImpl:
         self.mitigator = mitigator
 
     def _decode(self, y):
-        assert isinstance(y, pd.Series)
-        assert len(self.favorable_labels) == 1 and len(self.not_favorable_labels) == 1
+        assert isinstance(y, pd.Series), type(y)
+        assert len(self.favorable_labels) == 1, self.favorable_labels
+        assert len(self.not_favorable_labels) == 1, self.not_favorable_labels
         favorable, not_favorable = (
             self.favorable_labels[0],
             self.not_favorable_labels[0],

--- a/lale/lib/imblearn/_common_schemas.py
+++ b/lale/lib/imblearn/_common_schemas.py
@@ -36,7 +36,7 @@ _hparam_n_neighbors: JSON_TYPE = {
     "anyOf": [
         {
             "type": "integer",
-            "description": "Number of nearest neighbours to used to construct synthetic samples.",
+            "description": "Number of nearest neighbours to use to construct synthetic samples.",
         },
         {
             "laleType": "Any",

--- a/lale/lib/imblearn/borderline_smote.py
+++ b/lale/lib/imblearn/borderline_smote.py
@@ -55,7 +55,7 @@ _hyperparams_schema = {
                 "random_state": _hparam_random_state,
                 "k_neighbors": {
                     **_hparam_n_neighbors,
-                    "description": "Number of nearest neighbours to used to construct synthetic samples.",
+                    "description": "Number of nearest neighbours to use to construct synthetic samples.",
                     "default": 5,
                 },
                 "n_jobs": _hparam_n_jobs,

--- a/lale/lib/imblearn/smote.py
+++ b/lale/lib/imblearn/smote.py
@@ -56,7 +56,7 @@ _hyperparams_schema = {
                 "random_state": _hparam_random_state,
                 "k_neighbors": {
                     **_hparam_n_neighbors,
-                    "description": "Number of nearest neighbours to used to construct synthetic samples.",
+                    "description": "Number of nearest neighbours to use to construct synthetic samples.",
                     "default": 5,
                 },
                 "n_jobs": _hparam_n_jobs,

--- a/lale/lib/imblearn/smoten.py
+++ b/lale/lib/imblearn/smoten.py
@@ -56,7 +56,7 @@ _hyperparams_schema = {
                 "random_state": _hparam_random_state,
                 "k_neighbors": {
                     **_hparam_n_neighbors,
-                    "description": "Number of nearest neighbours to used to construct synthetic samples.",
+                    "description": "Number of nearest neighbours to use to construct synthetic samples.",
                     "default": 5,
                 },
                 "n_jobs": _hparam_n_jobs,

--- a/lale/lib/imblearn/smotenc.py
+++ b/lale/lib/imblearn/smotenc.py
@@ -86,7 +86,7 @@ _hyperparams_schema = {
                 "random_state": _hparam_random_state,
                 "k_neighbors": {
                     **_hparam_n_neighbors,
-                    "description": "Number of nearest neighbours to used to construct synthetic samples.",
+                    "description": "Number of nearest neighbours to use to construct synthetic samples.",
                     "default": 5,
                 },
                 "n_jobs": _hparam_n_jobs,

--- a/lale/lib/imblearn/svm_smote.py
+++ b/lale/lib/imblearn/svm_smote.py
@@ -56,7 +56,7 @@ _hyperparams_schema = {
                 "random_state": _hparam_random_state,
                 "k_neighbors": {
                     **_hparam_n_neighbors,
-                    "description": "Number of nearest neighbours to used to construct synthetic samples.",
+                    "description": "Number of nearest neighbours to use to construct synthetic samples.",
                     "default": 5,
                 },
                 "n_jobs": _hparam_n_jobs,


### PR DESCRIPTION
- suppress spurious tensorflow warnings
- option to preprocess only y for TAE dataset
- forward SMOTE hyperparameters from FairSMOTE
- better error message from post-estimator mitigators
- documentation typo