### PR TITLE
Increment lale version to 0.8.0

### DIFF
--- a/lale/__init__.py
+++ b/lale/__init__.py
@@ -14,7 +14,7 @@
 
 import sys
 
-__version__ = "0.7.11"
+__version__ = "0.8.0"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
- Add support for Python 3.11
  - The SMAC hyperoptimization backend is not currently supported on 3.11
- Add support for scikit-learn 1.3 and 1.4
- Update supported versions of numpy, scipy, pandas, xgboost, lightgbm, snapml, and tensorflow
  - AIF360 does not currently support numpy>=1.24, so testing for aif360 libraries is done using an older version of numpy
- Fix readthedocs build so our documentation is correctly updated
- Add label encoding to our wrapper for XGBClassifier, since it longer does this.
- Shuffle data in some batching tests to (mostly) avoid problems with encoding
- Remove support for Python 3.7 and scikit-learn < 1.0
- Remove autoai_libs wrappers and tests (they have been moved into the autoai_libs package).