### PR TITLE
Increment lale version to 0.8.1

### DIFF
--- a/lale/__init__.py
+++ b/lale/__init__.py
@@ -14,7 +14,7 @@
 
 import sys
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
* Fix for xgb classifier without a label encoder
* URL links fix to open them in new tab
* Use newer AIF360 version that does not require an upper bound on numpy version