### PR TITLE
docs: Remove numpy upper bound from docs build and mock mystic

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Optionally set the version of Python and requirements
 # required to build your docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,10 +96,11 @@ autodoc_mock_imports = [
     "aif360",
     "ConfigSpace",
     "fairlearn",
+    "mystic",
+    "numba",
     "pytorch",
     "tensorflow",
     "torch",
-    "numba",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 # all of setup.py -> install_requires
-numpy<2.0.0
+numpy
+# aif360>=0.5.0
 black==19.10b0
 graphviz
 hyperopt
@@ -13,7 +14,7 @@ h5py
 astunparse
 typing-extensions
 # subset of setup.py -> extras_require -> full
-mystic
+# mystic
 xgboost
 lightgbm<4.4.0
 liac-arff>=2.4.0


### PR DESCRIPTION
the latest release of mystic does not yet support numpy>=2.0.
At least one of the issues has been fixed in master: https://github.com/uqfoundation/mystic/pull/248
and there is an issue for completing the migration: https://github.com/uqfoundation/mystic/issues/249

This addresses #1375 