### PR TITLE
Increment lale version to 0.9.0

### DIFF
--- a/lale/__init__.py
+++ b/lale/__init__.py
@@ -14,7 +14,7 @@
 
 import sys
 
-__version__ = "0.8.4"
+__version__ = "0.9.0"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
Maintenance release that supports newer versions of dependencies.

- Add support for Python 3.12
- Add support for Numpy>=2.0
- Support newer versions of dependencies:
  - imbalanced-learn: 0.13
  - XGBoost: 3.0
  - lightgbm: 4.6
  - SnapML: 1.16
  - scikit-learn: 1.6
- Improvements to test datasets
  - Replace use of no longer available dataset
  - Enable support for prefetching and caching datasets in CI
- Update all static tools

Removals/Known Issues:
- Remove support for Python 3.8 and Python 3.9
  - Python 3.9 is still believed to work , but it is no longer tested as part of CI and hence no longer supported.
- Disable testing for RASL subsystem.
  - It should still work with older versions of Numpy and Python, however it currently breaks with newer versions
  - This breakage will hopefully be fixed, and tests re-enabled, in a future release.
- Testing now generally happens against Numpy>=2.0.  Numpy 1.X should still work, however it is no longer well-tested or supported.