### PR TITLE
Increment lale version to 0.9.1

### DIFF
--- a/lale/__init__.py
+++ b/lale/__init__.py
@@ -14,7 +14,7 @@
 
 import sys
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
Dependency updates:
* Make graphviz dependency optional
* Increase upper bound on jsonschema
* Upper bound pyspark dependency to < 4.0
* Support newer versions of numpy
* Add autoai-fairness dependency set with appropriate version bounds on depdendencies