### PR TITLE
Add upper bound on setup tools so that hyperopt is happy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         cache: 'pip'
         cache-dependency-path: setup.py
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [static]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -69,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -87,7 +87,7 @@ jobs:
         pip install pipdeptree
         pipdeptree -fl
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -97,7 +97,7 @@ jobs:
     - name: Download the test data
       run: python lale/datasets/prefetch.py
     - name: Cache test data save
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -156,9 +156,9 @@ jobs:
         #   setup-target: '.[full,test]'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -166,7 +166,7 @@ jobs:
     - name: Install system packages
       run: sudo apt-get install graphviz swig
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -246,9 +246,9 @@ jobs:
           setup-target: '.[full,test]'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -256,7 +256,7 @@ jobs:
     - name: Install system packages
       run: sudo apt-get install graphviz swig
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -296,9 +296,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
         setup-target: ['.']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -306,7 +306,7 @@ jobs:
     - name: Install system packages
       run: sudo apt-get install graphviz swig
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -358,15 +358,15 @@ jobs:
           # nbexcludes: '06_multobj.ipynb'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: setup.py
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -443,15 +443,15 @@ jobs:
           # nbexcludes: '06_multobj.ipynb'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: setup.py
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -494,9 +494,9 @@ jobs:
         python-version: ['3.11']
         setup-target: ['.[fairness]']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system packages
@@ -512,7 +512,7 @@ jobs:
         pip install pipdeptree
         pipdeptree -fl
     - name: Cache test data restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.DOWNLOAD_CACHE_DIR }}
         key: ${{ runner.os }}-dcache-new3-${{ env.DOWNLOAD_CACHE_DIR }}-${{ hashFiles('lale/datasets/prefetch.py') }}
@@ -532,9 +532,9 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,8 +355,7 @@ jobs:
           python-version: '3.11'
           setup-target: '.[tutorial,test]'
           test-case: 'test/test_notebooks.py'
-          # nbexcludes: '06_multobj.ipynb'
-
+          nbexcludes: '08_newops.ipynb'
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
@@ -425,23 +424,22 @@ jobs:
           python-version: '3.11'
           setup-target: '.[tutorial,test]'
           test-case: 'test/test_notebooks.py'
-          nbexcludes: '02_total.ipynb'
+          nbexcludes: '02_total.ipynb 08_newops.ipynb'
         - dir: 'examples/kdd22'
           python-version: '3.10'
           setup-target: '.[tutorial,test]'
           test-case: 'test/test_notebooks.py'
-          # nbexcludes: '06_multobj.ipynb'
+          nbexcludes: '08_newops.ipynb'
         - dir: 'examples/kdd22'
           python-version: '3.11'
           setup-target: '.[tutorial,test]'
           test-case: 'test/test_notebooks.py'
-          # nbexcludes: '06_multobj.ipynb'
+          nbexcludes: '08_newops.ipynb'
         - dir: 'examples/kdd22'
           python-version: '3.12'
           setup-target: '.[tutorial,test]'
           test-case: 'test/test_notebooks.py'
-          # nbexcludes: '06_multobj.ipynb'
-
+          nbexcludes: '08_newops.ipynb'
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,4 +67,4 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ['pyright@1.1.407']
+        additional_dependencies: ['pyright@1.1.398']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,4 +67,4 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ['pyright@1.1.398']
+        additional_dependencies: ['pyright@1.1.409']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,4 +67,4 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ['pyright@1.1.398']
+        additional_dependencies: ['pyright@1.1.407']

--- a/examples/kdd22/README.md
+++ b/examples/kdd22/README.md
@@ -140,6 +140,8 @@ documented.
 This notebook walks through the steps to add a new operator wrapper and
 to define a search space for that operator's hyperparameters.
 
+NB: While the Lale concepts remain the same, the underlying example no longer works.
+
 #### 9. Scikit-learn compatibility
 
 [09_compat.ipynb](09_compat.ipynb)

--- a/lale/datasets/data_schemas.py
+++ b/lale/datasets/data_schemas.py
@@ -26,10 +26,20 @@ from lale.type_checking import JSON_TYPE
 
 try:
     import torch
-    from torch import Tensor
+    from torch import (
+        Tensor,
+    )
+    from torch import bool as torch_bool  # pyright: ignore[reportPrivateImportUsage]
+    from torch import (
+        is_floating_point as torch_is_floating_point,  # pyright: ignore[reportPrivateImportUsage]
+    )
+    from torch import uint8 as torch_uint8  # pyright: ignore[reportPrivateImportUsage]
 except ImportError:
     torch = None
     Tensor = None
+    torch_bool = None  # type: ignore[assignment]
+    torch_uint8 = None  # type: ignore[assignment]
+    torch_is_floating_point = None  # type: ignore[assignment]
 
 try:
     from py4j.protocol import Py4JError
@@ -545,11 +555,11 @@ or with
     assert isinstance(tensor, Tensor)
     result: JSON_TYPE
     # https://pytorch.org/docs/stable/tensor_attributes.html#torch-dtype
-    if tensor.dtype == torch.bool:
+    if tensor.dtype == torch_bool:
         result = {"type": "boolean"}
-    elif tensor.dtype == torch.uint8:
+    elif tensor.dtype == torch_uint8:
         result = {"type": "integer", "minimum": 0, "maximum": 255}
-    elif torch.is_floating_point(tensor):
+    elif torch_is_floating_point(tensor):  # pyright: ignore[reportOptionalCall]
         result = {"type": "number"}
     else:
         result = {"type": "integer"}

--- a/lale/grammar.py
+++ b/lale/grammar.py
@@ -105,9 +105,9 @@ class Grammar(Operator):
 
     def __setattr__(self, name, value):
         if name.startswith("_"):
-            self.__dict__[name] = value
+            self.__dict__[name] = value  # pyright: ignore[reportIndexIssue]
         else:
-            self._variables[name] = value
+            self._variables[name] = value  # pyright: ignore[reportIndexIssue]
 
     def _has_same_impl(self, other: Operator):
         return False

--- a/lale/helpers.py
+++ b/lale/helpers.py
@@ -48,8 +48,14 @@ import lale.datasets.data_schemas
 
 try:
     import torch
+    from torch import cat as torch_cat  # pyright: ignore[reportPrivateImportUsage]
+    from torch import (
+        from_numpy as torch_from_numpy,  # pyright: ignore[reportPrivateImportUsage]
+    )
 except ImportError:
     torch = None
+    torch_cat = None  # type: ignore[assignment]
+    torch_from_numpy = None  # type: ignore[assignment]
 
 spark_loader = util.find_spec("pyspark")
 spark_installed = spark_loader is not None
@@ -841,7 +847,7 @@ def append_batch(data, batch_data):
             return X, y
     elif torch is not None and isinstance(data, torch.Tensor):
         if isinstance(batch_data, torch.Tensor):
-            return torch.cat((data, batch_data))
+            return torch_cat((data, batch_data))  # pyright: ignore[reportOptionalCall]
     elif isinstance(data, (pd.Series, pd.DataFrame)):
         return pd.concat([data, batch_data], axis=0)
     try:
@@ -946,7 +952,7 @@ def create_data_loader(
             return [X]
     elif isinstance(X, torch.Tensor) and y is not None:
         if isinstance(y, np.ndarray):
-            y = torch.from_numpy(y)
+            y = torch_from_numpy(y)  # pyright: ignore[reportOptionalCall]
         dataset = TensorDataset(X, y)
     elif isinstance(X, torch.Tensor):
         dataset = TensorDataset(X)
@@ -1021,10 +1027,10 @@ def write_batch_output_to_file(
         labels = file_obj["y"]
         if batch_out_y is not None:
             labels[
-                batch_idx * len(batch_out_y) : (batch_idx + 1) * len(batch_out_y)
+                batch_idx * len(batch_out_y) : (batch_idx + 1) * len(batch_out_y)  # type: ignore[arg-type]
             ] = batch_out_y
         else:
-            labels[batch_idx * len(batch_y) : (batch_idx + 1) * len(batch_y)] = batch_y
+            labels[batch_idx * len(batch_y) : (batch_idx + 1) * len(batch_y)] = batch_y  # type: ignore[arg-type]
     return file_obj
 
 
@@ -1264,12 +1270,12 @@ def _ensure_pandas(df) -> pd.DataFrame:
     return df
 
 
-def _get_subscript_value(subscript_expr):
+def _get_subscript_value(subscript_expr) -> str:
     if isinstance(subscript_expr.slice, ast.Constant):  # for Python 3.9
         subscript_value = subscript_expr.slice.value
     else:
         subscript_value = subscript_expr.slice.value.s  # type: ignore
-    return subscript_value
+    return str(subscript_value)
 
 
 class GenSym:

--- a/lale/lib/aif360/datasets.py
+++ b/lale/lib/aif360/datasets.py
@@ -661,7 +661,10 @@ def _get_compas_filename(violent_recidivism=False):
 
 def _get_compas_filepath(filename):
     directory = os.path.join(
-        os.path.dirname(os.path.abspath(aif360.__file__)), "data", "raw", "compas"
+        os.path.dirname(os.path.abspath(aif360.__file__)),  # type: ignore[arg-type]
+        "data",
+        "raw",
+        "compas",
     )
     return os.path.join(
         directory,
@@ -1553,7 +1556,7 @@ def _fetch_meps_raw_df(panel, fiscal_year):
         logger.error(f"Unexpected FiscalYear received: {fiscal_year}")
         raise ValueError(f"Unexpected FiscalYear received: {fiscal_year}")
     filepath = os.path.join(
-        os.path.dirname(os.path.abspath(aif360.__file__)),
+        os.path.dirname(os.path.abspath(aif360.__file__)),  # type: ignore[arg-type]
         "data",
         "raw",
         "meps",

--- a/lale/lib/aif360/util.py
+++ b/lale/lib/aif360/util.py
@@ -875,7 +875,7 @@ _Batch_Xy = Tuple[pd.DataFrame, pd.Series]
 _Batch_yyX = Tuple[Optional[pd.Series], pd.Series, pd.DataFrame]
 
 
-class _DIorSPDData(MetricMonoid):
+class _DIorSPDData(MetricMonoid["_DIorSPDData"]):
     def __init__(
         self, priv0_fav0: float, priv0_fav1: float, priv1_fav0: float, priv1_fav1: float
     ):
@@ -932,7 +932,7 @@ class _DIorSPDScorerFactory(_AIF360ScorerFactory):
         )
 
 
-class _AODorEODData(MetricMonoid):
+class _AODorEODData(MetricMonoid["_AODorEODData"]):
     def __init__(
         self,
         tru0_pred0_priv0: float,
@@ -1134,7 +1134,7 @@ _BLENDED_SCORER_DOCSTRING = (
 )
 
 
-class _AccuracyAndSymmDIData(MetricMonoid):
+class _AccuracyAndSymmDIData(MetricMonoid["_AccuracyAndSymmDIData"]):
     def __init__(
         self,
         accuracy_data: lale.lib.rasl.metrics._AccuracyData,
@@ -1319,7 +1319,7 @@ average_odds_difference.__doc__ = (
 )
 
 
-class _BalAccAndSymmDIData(MetricMonoid):
+class _BalAccAndSymmDIData(MetricMonoid["_BalAccAndSymmDIData"]):
     def __init__(
         self,
         bal_acc_data: lale.lib.rasl.metrics._BalancedAccuracyData,
@@ -1555,7 +1555,7 @@ equal_opportunity_difference.__doc__ = (
 )
 
 
-class _F1AndSymmDIData(MetricMonoid):
+class _F1AndSymmDIData(MetricMonoid["_F1AndSymmDIData"]):
     def __init__(
         self,
         f1_data: lale.lib.rasl.metrics._F1Data,
@@ -1691,7 +1691,7 @@ f1_and_disparate_impact.__doc__ = (
 )
 
 
-class _R2AndSymmDIData(MetricMonoid):
+class _R2AndSymmDIData(MetricMonoid["_R2AndSymmDIData"]):
     def __init__(
         self,
         r2_data: lale.lib.rasl.metrics._R2Data,

--- a/lale/lib/lale/hyperopt.py
+++ b/lale/lib/lale/hyperopt.py
@@ -125,7 +125,7 @@ class _HyperoptImpl:
         else:
             self.cv = check_cv(self.cv, y=y_train, classifier=is_clf)
         try:
-            data_schema = lale.helpers.fold_schema(X_train, y_train, self.cv, is_clf)
+            data_schema = lale.helpers.fold_schema(X_train, y_train, self.cv, is_clf)  # type: ignore[arg-type]
         except (
             BaseException
         ):  # we may not always be able to extract schema for the given data format.

--- a/lale/lib/rasl/filter.py
+++ b/lale/lib/rasl/filter.py
@@ -76,7 +76,7 @@ class _FilterImpl:
                 raise ValueError(
                     f"Cannot perform filter predicate operation as {lhs} not a column of input dataframe X."
                 )
-            return lhs, op, None
+            return str(lhs), op, None
 
         if _is_ast_subscript(expr_to_parse.left):
             lhs = _get_subscript_value(expr_to_parse.left)
@@ -105,7 +105,11 @@ class _FilterImpl:
             raise ValueError(
                 f"Cannot perform filter operation as {rhs} not a column of input dataframe X."
             )
-        return lhs, op, rhs
+        return (
+            str(lhs),
+            op,
+            str(rhs) if not _is_ast_constant(expr_to_parse.comparators[0]) else rhs,
+        )
 
     def transform(self, X):
         filtered_df = X

--- a/lale/lib/rasl/functions.py
+++ b/lale/lib/rasl/functions.py
@@ -114,7 +114,7 @@ class make_categorical_column:
 _D = TypeVar("_D", bound=Monoid)
 
 
-class DictMonoid(Generic[_D], Monoid):
+class DictMonoid(Monoid, Generic[_D]):
     """
     Given a monoid, this class lifts it to a dictionary pointwise
     """

--- a/lale/lib/rasl/join.py
+++ b/lale/lib/rasl/join.py
@@ -58,12 +58,12 @@ class _JoinImpl:
     # Parse the predicate element passed as input
     @classmethod
     def _get_join_info(cls, expr_to_parse):
-        left_key = []
-        right_key = []
+        left_key: List[str] = []
+        right_key: List[str] = []
         if _is_ast_subscript(expr_to_parse.left.value):
             left_name = _get_subscript_value(expr_to_parse.left.value)
         elif _is_ast_attribute(expr_to_parse.left.value):
-            left_name = expr_to_parse.left.value.attr
+            left_name = str(expr_to_parse.left.value.attr)
         else:
             raise ValueError(
                 "ERROR: Expression type not supported! Formats supported: it.table_name.column_name or it['table_name'].column_name"
@@ -71,7 +71,7 @@ class _JoinImpl:
         if _is_ast_subscript(expr_to_parse.left):
             left_key.append(_get_subscript_value(expr_to_parse.left))
         elif _is_ast_attribute(expr_to_parse.left):
-            left_key.append(expr_to_parse.left.attr)
+            left_key.append(str(expr_to_parse.left.attr))
         else:
             raise ValueError(
                 "ERROR: Expression type not supported! Formats supported: it.table_name.column_name or it.table_name['column_name']"
@@ -79,7 +79,7 @@ class _JoinImpl:
         if _is_ast_subscript(expr_to_parse.comparators[0].value):
             right_name = _get_subscript_value(expr_to_parse.comparators[0].value)
         elif _is_ast_attribute(expr_to_parse.comparators[0].value):
-            right_name = expr_to_parse.comparators[0].value.attr
+            right_name = str(expr_to_parse.comparators[0].value.attr)
         else:
             raise ValueError(
                 "ERROR: Expression type not supported! Formats supported: it.table_name.column_name or it['table_name'].column_name"
@@ -87,7 +87,7 @@ class _JoinImpl:
         if _is_ast_subscript(expr_to_parse.comparators[0]):
             right_key.append(_get_subscript_value(expr_to_parse.comparators[0]))
         elif _is_ast_attribute(expr_to_parse.comparators[0]):
-            right_key.append(expr_to_parse.comparators[0].attr)
+            right_key.append(str(expr_to_parse.comparators[0].attr))
         else:
             raise ValueError(
                 "ERROR: Expression type not supported! Formats supported: it.table_name.column_name or it.table_name['column_name']"

--- a/lale/lib/rasl/metrics.py
+++ b/lale/lib/rasl/metrics.py
@@ -134,7 +134,7 @@ def _make_dataframe_yy(batch):
     return result
 
 
-class _AccuracyData(MetricMonoid):
+class _AccuracyData(MetricMonoid["_AccuracyData"]):
     def __init__(self, match: int, total: int):
         self.match = match
         self.total = total
@@ -166,7 +166,7 @@ def accuracy_score(y_true: pd.Series, y_pred: pd.Series) -> float:
     return get_scorer("accuracy").score_data(y_true, y_pred)
 
 
-class _BalancedAccuracyData(MetricMonoid):
+class _BalancedAccuracyData(MetricMonoid["_BalancedAccuracyData"]):
     def __init__(self, true_pos: Dict[str, int], false_neg: Dict[str, int]):
         self.true_pos = true_pos
         self.false_neg = false_neg
@@ -223,7 +223,7 @@ def balanced_accuracy_score(y_true: pd.Series, y_pred: pd.Series) -> float:
     return get_scorer("balanced_accuracy").score_data(y_true, y_pred)
 
 
-class _F1Data(MetricMonoid):
+class _F1Data(MetricMonoid["_F1Data"]):
     def __init__(self, true_pos: int, false_pos: int, false_neg: int):
         self.true_pos = true_pos
         self.false_pos = false_pos
@@ -284,7 +284,7 @@ def f1_score(
     return get_scorer("f1", pos_label=pos_label).score_data(y_true, y_pred)
 
 
-class _R2Data(MetricMonoid):
+class _R2Data(MetricMonoid["_R2Data"]):
     def __init__(self, n: int, tot_sum: float, tot_sum_sq: float, res_sum_sq: float):
         self.n = n
         self.sum = tot_sum

--- a/lale/lib/rasl/monoid.py
+++ b/lale/lib/rasl/monoid.py
@@ -20,7 +20,7 @@ _OutputType_co = TypeVar("_OutputType_co", covariant=True)
 _SelfType = TypeVar("_SelfType")
 
 
-class Monoid(ABC):
+class Monoid(ABC, Generic[_SelfType]):
     """
     Data that can be combined in an associative way.  See :class:MonoidFactory for ways to create/unpack
     a given monoid.

--- a/lale/lib/rasl/orderby.py
+++ b/lale/lib/rasl/orderby.py
@@ -68,15 +68,15 @@ class _OrderByImpl:
         if isinstance(arg, str):
             col = arg
         elif isinstance(arg, ast.Name):
-            col = arg.id  # type: ignore
+            col = str(arg.id)  # type: ignore
         elif hasattr(ast, "Constant") and isinstance(arg, ast.Constant):
-            col = arg.value  # type: ignore
+            col = str(arg.value)  # type: ignore
         elif hasattr(ast, "Str") and isinstance(arg, ast.Str):
-            col = arg.s
+            col = str(arg.s)
         elif _is_ast_subscript(arg):
-            col = arg.slice.value.s  # type: ignore
+            col = str(arg.slice.value.s)  # type: ignore
         elif _is_ast_attribute(arg):
-            col = arg.attr  # type: ignore
+            col = str(arg.attr)  # type: ignore
         else:
             raise ValueError(
                 "OrderBy parameters only support string, subscript or dot notation for the column name. For example, it.col_name or it['col_name']."

--- a/lale/lib/rasl/scan.py
+++ b/lale/lib/rasl/scan.py
@@ -26,7 +26,7 @@ class _ScanImpl:
     def __init__(self, table=None):
         assert table is not None
         if isinstance(table.expr, ast.Attribute):
-            self.table_name = table.expr.attr
+            self.table_name: str = table.expr.attr
         elif isinstance(table.expr, ast.Subscript):
             self.table_name = _get_subscript_value(table.expr)
 

--- a/lale/lib/snapml/snap_boosting_machine_classifier.py
+++ b/lale/lib/snapml/snap_boosting_machine_classifier.py
@@ -11,17 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from packaging import version
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
+from .utils import get_snapml_version
+
 try:
     import snapml
     from snapml import SnapBoostingMachineClassifier as Base
 
-    snapml_version = version.parse(getattr(snapml, "__version__"))
+    snapml_version: Optional[version.Version] = get_snapml_version(snapml)
+
 
 except ImportError:
     Base = None

--- a/lale/lib/snapml/snap_boosting_machine_regressor.py
+++ b/lale/lib/snapml/snap_boosting_machine_regressor.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from packaging import version
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
+from .utils import get_snapml_version
+
 try:
     import snapml
     from snapml import SnapBoostingMachineRegressor as Base
 
-    snapml_version = version.parse(getattr(snapml, "__version__"))
+    snapml_version: Optional[version.Version] = get_snapml_version(snapml)
 except ImportError:
     Base = None
     snapml_version = None

--- a/lale/lib/snapml/snap_random_forest_classifier.py
+++ b/lale/lib/snapml/snap_random_forest_classifier.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from packaging import version
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
+from .utils import get_snapml_version
+
 try:
     import snapml
     from snapml import SnapRandomForestClassifier as Base
 
-    snapml_version = version.parse(getattr(snapml, "__version__"))
+    snapml_version: Optional[version.Version] = get_snapml_version(snapml)
 except ImportError:
     Base = None
     snapml_version = None

--- a/lale/lib/snapml/snap_random_forest_regressor.py
+++ b/lale/lib/snapml/snap_random_forest_regressor.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from packaging import version
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
+from .utils import get_snapml_version
+
 try:
     import snapml
     from snapml import SnapRandomForestRegressor as Base
 
-    snapml_version = version.parse(getattr(snapml, "__version__"))
+    snapml_version: Optional[version.Version] = get_snapml_version(snapml)
 except ImportError:
     Base = None
     snapml_version = None

--- a/lale/lib/snapml/snap_svm_classifier.py
+++ b/lale/lib/snapml/snap_svm_classifier.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
 from packaging import version
 
 import lale.datasets.data_schemas
 import lale.docstrings
 import lale.operators
 
+from .utils import get_snapml_version
+
 try:
     import snapml
     from snapml import SnapSVMClassifier as Base
 
-    snapml_version = version.parse(getattr(snapml, "__version__"))
+    snapml_version: Optional[version.Version] = get_snapml_version(snapml)
 
 except ImportError:
     Base = None

--- a/lale/lib/snapml/utils.py
+++ b/lale/lib/snapml/utils.py
@@ -1,0 +1,16 @@
+from types import ModuleType
+from typing import Optional
+
+from packaging import version
+
+
+def get_snapml_version(snapml: ModuleType) -> Optional[version.Version]:
+    version_str = getattr(snapml, "__version__", None)
+    if version_str is None:
+        version_pkg = getattr(snapml, "version", None)
+        if version_pkg is not None:
+            version_str = getattr(version_pkg, "__version__", None)
+    if isinstance(version_str, str):
+        return version.parse(version_str)
+    else:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0,<82.0"]
 build-backend = "setuptools.build_meta"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,4 @@
 {
-  "exclude": ["build"],
+  "exclude": ["build", ".venv"],
   "useLibraryCodeForTypes": false
 }

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ extras_require = {
         "graphviz",
         "xgboost<3.1.0",
         "lightgbm<4.7.0",
-        "snapml>=1.7.0rc3,<1.17.0",
+        "snapml>=1.7.0rc3,<1.18.0",
         "liac-arff>=2.4.0",
         "tensorflow>=2.4.0",
         "numba",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ else:
         "jsonsubschema>=0.0.6",
         "scikit-learn>=1.0.0,<1.8.0",
         "scipy",
-        "pandas",
+        "pandas<3.0.0",
         "packaging",
         "decorator",
         "typing-extensions",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ else:
     install_requires = [
         "numpy",
         "black>=22.1.0",
+        "setuptools>=61.0,<82.0",  # needed for hyperopt
         "hyperopt>=0.2,<=0.2.7",
         "jsonschema<=5",
         "jsonsubschema>=0.0.6",

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -714,7 +714,7 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
             favorable_labels={1},
             sampling_strategy="mixed",
         )
-        self.assertDictEqual(nsizes, {"00": 122, "01": 122, "10": 398, "11": 398})
+        self.assertDictEqual(nsizes, {"00": 187, "01": 187, "10": 386, "11": 386})
 
     def test_pick_sizes_mixed_single_pa_single_class_reversed(self):
         nsizes = _orbis_pick_sizes(
@@ -724,7 +724,7 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
             favorable_labels={1},
             sampling_strategy="mixed",
         )
-        self.assertDictEqual(nsizes, {"00": 398, "01": 398, "10": 122, "11": 122})
+        self.assertDictEqual(nsizes, {"00": 386, "01": 386, "10": 187, "11": 187})
 
     def test_pick_sizes_mixed_multi_pa_multi_class_normal(self):
         osizes = {
@@ -751,18 +751,18 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
         self.assertDictEqual(
             nsizes,
             {
-                "000": 573,
+                "000": 674,
                 "001": 670,
-                "002": 725,
-                "010": 923,
+                "002": 678,
+                "010": 899,
                 "011": 970,
-                "012": 1059,
-                "100": 7246,
+                "012": 1029,
+                "100": 7152,
                 "101": 7170,
-                "102": 7137,
-                "110": 7406,
+                "102": 7177,
+                "110": 7423,
                 "111": 7471,
-                "112": 7495,
+                "112": 7532,
             },
         )
 
@@ -791,17 +791,17 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
         self.assertDictEqual(
             nsizes,
             {
-                "002": 1406,
+                "002": 1501,
                 "000": 1200,
-                "001": 1308,
+                "001": 1496,
                 "012": 700,
                 "010": 900,
                 "011": 800,
                 "102": 400,
                 "100": 600,
                 "101": 500,
-                "112": 306,
-                "110": 111,
+                "112": 400,
+                "110": 299,
                 "111": 200,
             },
         )
@@ -851,17 +851,17 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
         self.assertDictEqual(
             nsizes,
             {
-                "000": 570,
+                "000": 571,
                 "001": 670,
                 "002": 770,
-                "010": 884,
-                "011": 970,
+                "010": 1074,
+                "011": 1065,
                 "012": 1070,
-                "100": 7244,
-                "101": 7223,
+                "100": 7177,
+                "101": 7190,
                 "102": 7270,
-                "110": 7571,
-                "111": 7541,
+                "110": 7447,
+                "111": 7479,
                 "112": 7571,
             },
         )
@@ -952,17 +952,17 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
             nsizes,
             {
                 "000": 570,
-                "001": 627,
-                "002": 761,
+                "001": 651,
+                "002": 769,
                 "010": 870,
-                "011": 968,
-                "012": 976,
+                "011": 859,
+                "012": 799,
                 "100": 7070,
                 "101": 7170,
-                "102": 7129,
+                "102": 7169,
                 "110": 7370,
-                "111": 7381,
-                "112": 7414,
+                "111": 7466,
+                "112": 7543,
             },
         )
 
@@ -995,11 +995,11 @@ class TestAIF360OrbisPickSizes(unittest.TestCase):
                 "111": 100,
                 "110": 100,
                 "102": 400,
-                "101": 498,
-                "100": 304,
+                "101": 495,
+                "100": 307,
                 "012": 700,
-                "011": 655,
-                "010": 748,
+                "011": 658,
+                "010": 745,
                 "002": 1150,
                 "001": 1100,
                 "000": 1200,

--- a/test/test_aif360.py
+++ b/test/test_aif360.py
@@ -243,7 +243,10 @@ class TestAIF360Datasets(unittest.TestCase):
     @classmethod
     def _try_download_csv(cls, filename):
         directory = os.path.join(
-            os.path.dirname(os.path.abspath(aif360.__file__)), "data", "raw", "meps"
+            os.path.dirname(os.path.abspath(aif360.__file__)),  # type: ignore[arg-type]
+            "data",
+            "raw",
+            "meps",
         )
         csv_exists = os.path.exists(
             os.path.join(
@@ -270,7 +273,10 @@ class TestAIF360Datasets(unittest.TestCase):
     @classmethod
     def _cleanup_meps(cls, filename):
         directory = os.path.join(
-            os.path.dirname(os.path.abspath(aif360.__file__)), "data", "raw", "meps"
+            os.path.dirname(os.path.abspath(aif360.__file__)),  # type: ignore[arg-type]
+            "data",
+            "raw",
+            "meps",
         )
         filename_without_extension = os.path.splitext(filename)[0]
         zip_filename = f"{filename_without_extension}ssp.zip"


### PR DESCRIPTION
The latest released version of hyperopt uses pkg_resources which was removed from setuptools in version 82.

This issue is fixed by https://github.com/jic-dtool/dtoolcore/pull/37 however there is currently no release of hyperopt with this fix included.

Such a release has been requested here: https://github.com/hyperopt/hyperopt/issues/943