### PR TITLE
Update lale version to 0.9.3

### DIFF
--- a/lale/__init__.py
+++ b/lale/__init__.py
@@ -14,7 +14,7 @@
 
 import sys
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 try:
     # This variable is injected in the __builtins__ by the build


### PR DESCRIPTION
- Hyperopt compatibility fixes 
  - Add upper bounds to setuptools
  - Workaround for hyperopt.anneal strategy
- Support newer versions of snapml
- Fix tests
  - Accomodate minor changes in orbis output
  - Disable testing newop tutorial notebook due to trouble downloading the dataset
- Tooling improvements 
  - Update pyright version
  - Update github actions versions