### PR TITLE
DOC: add Snap ML example

### DIFF
--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -21,7 +21,7 @@ Example
 =======
 
 This example demonstrates a simple Lale pipeline using SnapLogisticRegression,
-including schema validation and operator composition:
+including schema validation and operator composition: 
 
 .. code-block:: python
     

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -17,7 +17,7 @@ Schema-enhanced versions of the operators from `Snap ML`_ to enable hyperparamet
 
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 
-Example
+Example 
 =======
 
 This example demonstrates a simple Lale pipeline using SnapLogisticRegression,

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -17,7 +17,7 @@ Schema-enhanced versions of the operators from `Snap ML`_ to enable hyperparamet
 
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 
-Example 
+Example
 =======
 
 This example demonstrates a simple Lale pipeline using SnapLogisticRegression,

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -20,24 +20,33 @@ Schema-enhanced versions of the operators from `Snap ML`_ to enable hyperparamet
 Example
 =======
 
-The following example shows how to use a Snap ML classifier with Lale on a binary classification dataset::
+This example demonstrates a simple Lale pipeline using SnapLogisticRegression,
+including schema validation and operator composition:
 
+.. code-block:: python
+    
     from lale.lib.snapml import SnapLogisticRegression
+    from lale.operators import make_pipeline
     from sklearn.datasets import load_breast_cancer
-    from sklearn.metrics import accuracy_score
     from sklearn.model_selection import train_test_split
-
+    
+    # Load dataset
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, random_state=42
-    )
-
-    clf = SnapLogisticRegression()
-    clf = clf.fit(X_train, y_train)
-    predictions = clf.predict(X_test)
-
-    print(accuracy_score(y_test, predictions))
-
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    
+    # Create a Lale pipeline (shows Lale-specific features)
+    pipe = make_pipeline(SnapLogisticRegression())
+    
+    # Fit the pipeline
+    pipe = pipe.fit(X_train, y_train)
+    
+    # Make predictions
+    predictions = pipe.predict(X_test)
+    print(predictions)
+    
+    # Show schema validation (feature beyond scikit-learn)
+    pipe.print_schema()
+    
 Operators
 =========
 

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -42,7 +42,7 @@ from Lale and inspect its hyperparameter schema:
     trained = trainable.fit(X_train, y_train)
     predictions = trained.predict(X_test)
     print(accuracy_score(y_test, predictions))
-    
+
 Operators
 =========
 
@@ -75,6 +75,7 @@ Regressors:
 .. _`SnapRandomForestRegressor`: lale.lib.snapml.snap_random_forest_regressor.html
 .. _`SnapSVMClassifier`: lale.lib.snapml.snap_svm_classifier.html
 """
+
 from lale import register_lale_wrapper_modules
 
 from .batched_tree_ensemble_classifier import (

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -20,32 +20,28 @@ Schema-enhanced versions of the operators from `Snap ML`_ to enable hyperparamet
 Example
 =======
 
-This example demonstrates a simple Lale pipeline using SnapLogisticRegression,
-including schema validation and operator composition: 
+The following example shows how to use a schema-enhanced Snap ML classifier
+from Lale and inspect its hyperparameter schema:
 
 .. code-block:: python
-    
+
     from lale.lib.snapml import SnapLogisticRegression
-    from lale.operators import make_pipeline
     from sklearn.datasets import load_breast_cancer
+    from sklearn.metrics import accuracy_score
     from sklearn.model_selection import train_test_split
-    
-    # Load dataset
+
     X, y = load_breast_cancer(return_X_y=True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    
-    # Create a Lale pipeline (shows Lale-specific features)
-    pipe = make_pipeline(SnapLogisticRegression())
-    
-    # Fit the pipeline
-    pipe = pipe.fit(X_train, y_train)
-    
-    # Make predictions
-    predictions = pipe.predict(X_test)
-    print(predictions)
-    
-    # Show schema validation (feature beyond scikit-learn)
-    pipe.print_schema()
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, random_state=42
+    )
+
+    trainable = SnapLogisticRegression()
+    hyperparam_schema = trainable.get_schema("hyperparams")
+    print(hyperparam_schema["description"])
+
+    trained = trainable.fit(X_train, y_train)
+    predictions = trained.predict(X_test)
+    print(accuracy_score(y_test, predictions))
     
 Operators
 =========

--- a/lale/lib/snapml/__init__.py
+++ b/lale/lib/snapml/__init__.py
@@ -17,6 +17,27 @@ Schema-enhanced versions of the operators from `Snap ML`_ to enable hyperparamet
 
 .. _`Snap ML`: https://www.zurich.ibm.com/snapml/
 
+Example
+=======
+
+The following example shows how to use a Snap ML classifier with Lale on a binary classification dataset::
+
+    from lale.lib.snapml import SnapLogisticRegression
+    from sklearn.datasets import load_breast_cancer
+    from sklearn.metrics import accuracy_score
+    from sklearn.model_selection import train_test_split
+
+    X, y = load_breast_cancer(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, random_state=42
+    )
+
+    clf = SnapLogisticRegression()
+    clf = clf.fit(X_train, y_train)
+    predictions = clf.predict(X_test)
+
+    print(accuracy_score(y_test, predictions))
+
 Operators
 =========
 


### PR DESCRIPTION
This PR adds a simple code example to the lale.lib.snapml module documentation.
The example shows how to use SnapLogisticRegression with a scikit-learn binary classification dataset, train/test split, prediction, and accuracy evaluation.
Related issue: #1368