### PR TITLE
FIX: improve missing ConcatFeatures error message

### DIFF
--- a/lale/operators.py
+++ b/lale/operators.py
@@ -2276,7 +2276,7 @@ class IndividualOp(Operator):
                     f"threw exception {e}"
                 )
                 # TODO: Is this really a reasonable fallback?
-                instance = class_.__new__()  # type:ignore
+                instance = class_.__new__()  # type: ignore
             self._impl = instance
         return self._impl
 
@@ -2543,8 +2543,26 @@ class IndividualOp(Operator):
                 except SubschemaError as e:
                     sub_str: str = lale.pretty_print.json_to_string(e.sub)
                     sup_str: str = lale.pretty_print.json_to_string(e.sup)
+                    hint = ""
+                    if (
+                        arg_name == "X"
+                        and isinstance(e.sub, dict)
+                        and e.sub.get("type") == "array"
+                        and isinstance(e.sub.get("items"), list)
+                        and len(e.sub["items"]) > 1
+                        and isinstance(e.sup, dict)
+                        and e.sup.get("type") == "array"
+                        and isinstance(e.sup.get("items"), dict)
+                    ):
+                        hint = (
+                            "\nThe actual data appears to contain multiple outputs. "
+                            "If this input comes from a pipeline using `&`, you may need to "
+                            "combine the parallel outputs with `ConcatFeatures`, for example "
+                            "`(op1 & op2) >> ConcatFeatures >> estimator`."
+                        )
                     raise ValueError(
-                        f"{self.name()}.{method}() invalid {arg_name}, the schema of the actual data is not a subschema of the expected schema of the argument.\nactual_schema = {sub_str}\nexpected_schema = {sup_str}"
+                        f"{self.name()}.{method}() invalid {arg_name}, the schema of the actual data is not a subschema of the expected schema of the argument."
+                        f"{hint}\nactual_schema = {sub_str}\nexpected_schema = {sup_str}"
                     ) from None
                 except Exception as e:
                     exception_type = f"{type(e).__module__}.{type(e).__name__}"
@@ -5171,7 +5189,7 @@ class OperatorChoice(PlannedOperator, Generic[OperatorChoiceType_co]):
             choice_index = 0
             chosen_params = impl_params
         else:
-            (choice_index, chosen_params) = partition_sklearn_choice_params(impl_params)
+            choice_index, chosen_params = partition_sklearn_choice_params(impl_params)
 
         assert 0 <= choice_index < len(choices)
         choice: Operator = choices[choice_index]
@@ -5663,7 +5681,7 @@ def with_structured_params(
             if len(sub_op) == 1:
                 sub_op = sub_op[0]
             else:
-                (disc, chosen_params) = partition_sklearn_choice_params(params)
+                disc, chosen_params = partition_sklearn_choice_params(params)
                 assert 0 <= disc < len(sub_op)
                 sub_op = sub_op[disc]
                 params = chosen_params

--- a/test/test_core_pipeline.py
+++ b/test/test_core_pipeline.py
@@ -16,11 +16,11 @@ import pickle
 import traceback
 import typing
 import unittest
-import pytest
 
 import numpy as np
 import sklearn.datasets
 import sklearn.pipeline
+from sklearn.datasets import load_iris
 from sklearn.feature_selection import SelectKBest as SkSelectKBest
 from sklearn.metrics import accuracy_score, r2_score
 from sklearn.model_selection import train_test_split
@@ -1130,12 +1130,6 @@ class TestPartialFit(unittest.TestCase):
             )
 
     def test_missing_concat_features_error_message(self):
-        from sklearn.datasets import load_iris
-
-        import lale.settings
-        from lale.lib.lale import NoOp
-        from lale.lib.sklearn import LogisticRegression, PCA
-
         X, y = load_iris(return_X_y=True)
         trainable = (PCA() & NoOp) >> LogisticRegression()
 

--- a/test/test_core_pipeline.py
+++ b/test/test_core_pipeline.py
@@ -27,6 +27,7 @@ from sklearn.model_selection import train_test_split
 
 import lale.datasets.openml
 import lale.helpers
+import lale.settings as lale_settings
 from lale.helpers import import_from_sklearn_pipeline
 from lale.lib.lale import ConcatFeatures, NoOp
 from lale.lib.sklearn import (
@@ -871,7 +872,6 @@ class TestAutoPipeline(unittest.TestCase):
 
 class TestOperatorChoice(unittest.TestCase):
     def test_make_choice_with_instance(self):
-        from sklearn.datasets import load_iris
 
         iris = load_iris()
         X, y = iris.data, iris.target
@@ -1134,14 +1134,14 @@ class TestPartialFit(unittest.TestCase):
         trainable = (PCA() & NoOp) >> LogisticRegression()
 
         old_disable_data_schema_validation = (
-            lale.settings.disable_data_schema_validation
+            lale_settings.disable_data_schema_validation
         )
         try:
-            lale.settings.set_disable_data_schema_validation(False)
+            lale_settings.set_disable_data_schema_validation(False)
             with self.assertRaises(ValueError) as exc_info:
                 trainable.fit(X, y)
         finally:
-            lale.settings.set_disable_data_schema_validation(
+            lale_settings.set_disable_data_schema_validation(
                 old_disable_data_schema_validation
             )
 

--- a/test/test_core_pipeline.py
+++ b/test/test_core_pipeline.py
@@ -16,6 +16,7 @@ import pickle
 import traceback
 import typing
 import unittest
+import pytest
 
 import numpy as np
 import sklearn.datasets
@@ -1127,3 +1128,29 @@ class TestPartialFit(unittest.TestCase):
                 freeze_trained_prefix=False,
                 classes=[0, 1, 2],
             )
+
+    def test_missing_concat_features_error_message(self):
+        from sklearn.datasets import load_iris
+
+        import lale.settings
+        from lale.lib.lale import NoOp
+        from lale.lib.sklearn import LogisticRegression, PCA
+
+        X, y = load_iris(return_X_y=True)
+        trainable = (PCA() & NoOp) >> LogisticRegression()
+
+        old_disable_data_schema_validation = (
+            lale.settings.disable_data_schema_validation
+        )
+        try:
+            lale.settings.set_disable_data_schema_validation(False)
+            with self.assertRaises(ValueError) as exc_info:
+                trainable.fit(X, y)
+        finally:
+            lale.settings.set_disable_data_schema_validation(
+                old_disable_data_schema_validation
+            )
+
+        message = str(exc_info.exception)
+        self.assertIn("ConcatFeatures", message)
+        self.assertIn("pipeline using `&`", message)


### PR DESCRIPTION
Fixes #663.

This PR improves the schema validation error message for pipelines where the output of the & combinator is passed directly into an estimator.

When the actual input schema appears to contain multiple parallel outputs, the error message now suggests using ConcatFeatures.

It also adds a regression test for this case.

Tested locally with:

`python -m pytest test\test_core_pipeline.py -k missing_concat_features_error_message`

Result: `1 passed, 79 deselected`.