### PR TITLE
FIX: add AutoPipeline predict_proba

### DIFF
--- a/lale/lib/lale/auto_pipeline.py
+++ b/lale/lib/lale/auto_pipeline.py
@@ -280,6 +280,11 @@ class _AutoPipelineImpl:
         result = best_pipeline.predict(X, **predict_params)
         return result
 
+    def predict_proba(self, X, **predict_proba_params):
+        best_pipeline = self._pipelines[self._name_of_best]
+        result = best_pipeline.predict_proba(X, **predict_proba_params)
+        return result
+
     def summary(self):
         """Table summarizing the trial results (name, tid, loss, time, log_loss, status).
         Returns
@@ -394,12 +399,19 @@ _input_predict_schema = {
     },
 }
 
+_input_predict_proba_schema = _input_predict_schema
+
 _output_predict_schema = {
     "anyOf": [
         {"type": "array", "items": {"type": "number"}},
         {"type": "array", "items": {"type": "string"}},
         {"type": "array", "items": {"type": "boolean"}},
     ]
+}
+
+_output_predict_proba_schema = {
+    "type": "array",
+    "items": {"type": "array", "items": {"type": "number"}},
 }
 
 _combined_schemas = {
@@ -421,6 +433,8 @@ For an example, see `demo_auto_pipeline.ipynb`_.
         "input_fit": _input_fit_schema,
         "input_predict": _input_predict_schema,
         "output_predict": _output_predict_schema,
+        "input_predict_proba": _input_predict_proba_schema,
+        "output_predict_proba": _output_predict_proba_schema,
     },
 }
 

--- a/test/test_core_pipeline.py
+++ b/test/test_core_pipeline.py
@@ -809,6 +809,28 @@ class TestAutoPipeline(unittest.TestCase):
         all_X, all_y = sklearn.datasets.load_iris(return_X_y=True)
         self._fit_predict("classification", all_X, all_y)
 
+    def test_predict_proba_with_roc_auc(self):
+        from lale.lib.lale import AutoPipeline
+
+        all_X, all_y = sklearn.datasets.load_breast_cancer(return_X_y=True)
+        train_X, test_X, train_y, _test_y = train_test_split(
+            all_X, all_y, test_size=0.2, random_state=42
+        )
+
+        trainable = AutoPipeline(
+            prediction_type="classification",
+            scoring="roc_auc",
+            max_evals=5,
+            max_opt_time=60,
+            max_eval_time=30,
+            cv=3,
+        )
+        trained = trainable.fit(train_X, train_y)
+        predicted_proba = trained.predict_proba(test_X)
+
+        self.assertEqual(predicted_proba.shape[0], test_X.shape[0])
+        self.assertEqual(predicted_proba.shape[1], 2)
+
     def test_sklearn_digits(self):
         # classification, numbers but some appear categorical, no missing values
         all_X, all_y = sklearn.datasets.load_digits(return_X_y=True)


### PR DESCRIPTION
Fixes #642.

This PR adds predict_proba support to AutoPipeline by delegating to the selected best trained pipeline.

It also adds `input_predict_proba` and `output_predict_proba` schemas for AutoPipeline.

A regression test was added for `AutoPipeline(scoring="roc_auc")` to fit the model and check the shape of `predict_proba`.

tested locally with:

`python -m pytest test/test_core_pipeline.py -k predict_proba_with_roc_auc`

Result: `1 passed, 79 deselected`.